### PR TITLE
Add an option to output in ntop's TLV format.

### DIFF
--- a/cmd/netflow2ng.go
+++ b/cmd/netflow2ng.go
@@ -63,6 +63,7 @@ type CLI struct {
 	SourceId  SourceId `kong:"help='NetFlow SourceId (0-255)',default=0"`
 	Compress  bool     `kong:"help='Compress ZMQ JSON data',xor='zmq-data'"`
 	Protobuf  bool     `kong:"help='Use ProtoBuff instead of JSQN for ZMQ',xor='zmq-data'"`
+	TLV       bool     `kong:"help='Use TLV instead of JSQN for ZMQ (needed for ntopng 6.4 and later)',xor='zmq-data'"`
 
 	Workers   int    `kong:"short='w',help='Number of NetFlow workers',default=1"`
 	LogLevel  string `kong:"short='l',help='Log level [error|warn|info|debug|trace]',default='info',enum='error,warn,info,debug,trace'"`

--- a/cmd/ntoptlv.go
+++ b/cmd/ntoptlv.go
@@ -1,0 +1,178 @@
+package main
+
+/*
+ * Encapulate the TLV format accepted by ntop tools.
+ *
+ * Ntopng parses this format using ndpi_serializer.c code in the ntop nDPI repository
+ * This code implements a subset of that format.
+ *
+ * A flow message a 2-byte header (always 0x01 0x01), a list of key/value pairs called 'items'
+ * and then a final end_of_record byte. For each item, the format is:
+ * Types        - 1 byte. left most 4 bit are key type, right most are value type.
+ * Key Length   - 2 bytes. Optional, only used when key type is string.
+ * Key          - 0-4 bytes if a uint/int type, "Key Length" bytes if string.
+ * Value Length - 2 bytes. Optional, only used when value type is string.
+ * Value        - 0-4 bytes if a uint/int type, "Value Length" bytes if string.
+ *
+ * Examples:
+ * 0x22 0x0a 0x0b
+ * ^^^ K is unit8, V is unit8. K=10,V=11.
+ * 0x23 0x0b 0x1f46
+ * ^^^ K is unit8, V is unit16, K=11, V=8006
+ * 0x2b 0x82 0x000c 0x31 0x37 0x32 0x2e 0x31 0x36 0x2e 0x31 0x2e 0x32 0x35 0x34
+ * ^^^ K is unit8, V is string, K=130, v length is 12, V='172.16.1.254'
+ *
+ * Another feature of this format is that numeric keys and values are reduced to a smaller size
+ * if possible. Example: A uint64 value of '8006' will be serialized as value type of uint16 and
+ * only two bytes used for the value.
+ */
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"reflect"
+
+	"github.com/cloudflare/goflow/v3/decoders/netflow"
+)
+
+// Taken From ntop nDPI's ndpi_typedefs.h. We're only using a subset.
+const (
+	//ndpi_serialization_unknown        uint8 = 0
+	ndpi_serialization_end_of_record uint8 = 1
+	ndpi_serialization_uint8         uint8 = 2
+	ndpi_serialization_uint16        uint8 = 3
+	ndpi_serialization_uint32        uint8 = 4
+	ndpi_serialization_uint64        uint8 = 5
+	ndpi_serialization_int8          uint8 = 6
+	ndpi_serialization_int16         uint8 = 7
+	ndpi_serialization_int32         uint8 = 8
+	ndpi_serialization_int64         uint8 = 9
+	//ndpi_serialization_float          uint8 = 10
+	ndpi_serialization_string uint8 = 11
+	//ndpi_serialization_start_of_block uint8 = 12
+	//ndpi_serialization_end_of_block   uint8 = 13
+	//ndpi_serialization_start_of_list  uint8 = 14
+	//ndpi_serialization_end_of_list    uint8= 15
+)
+
+// According to the nDPI library, key's can only be uint32 or string. But for our use all keys
+// will be from netflow/nfv9.go, so always uint16.
+type NdpiItem struct {
+	Key   uint16
+	Value interface{}
+}
+
+// ndpi_serialize_* functions in nDPI try to compant
+func minimalBytesUint(v uint64) (minType uint8, minBytes []byte) {
+	if v <= 0xff {
+		minType = ndpi_serialization_uint8
+		minBytes = []byte{byte(v)}
+	} else if v <= 0xffff {
+		minType = ndpi_serialization_uint16
+		minBytes = make([]byte, 2)
+		binary.BigEndian.PutUint16(minBytes, uint16(v))
+	} else if v <= 0xffffffff {
+		minType = ndpi_serialization_uint32
+		minBytes = make([]byte, 4)
+		binary.BigEndian.PutUint32(minBytes, uint32(v))
+	} else {
+		minType = ndpi_serialization_uint64
+		minBytes = make([]byte, 8)
+		binary.BigEndian.PutUint64(minBytes, v)
+	}
+	return minType, minBytes
+}
+
+// ndpi_serialize_* functions in nDPI try to compant
+func minimalBytesInt(v int64) (minType uint8, minBytes []byte) {
+	if v <= 0xff {
+		minType = ndpi_serialization_int8
+		minBytes = []byte{byte(v)}
+	} else if v <= 0xffff {
+		minType = ndpi_serialization_int16
+		minBytes = make([]byte, 2)
+		binary.BigEndian.PutUint16(minBytes, uint16(v))
+	} else if v <= 0xffffffff {
+		minType = ndpi_serialization_int32
+		minBytes = make([]byte, 4)
+		binary.BigEndian.PutUint32(minBytes, uint32(v))
+	} else {
+		minType = ndpi_serialization_int64
+		minBytes = make([]byte, 8)
+		binary.BigEndian.PutUint64(minBytes, uint64(v))
+	}
+	return minType, minBytes
+}
+
+func SerializeTlvItem(item NdpiItem) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	keyType := uint8(0)
+	valueType := uint8(0)
+	var minBytes []byte
+	var err error
+
+	keyType, minBytes = minimalBytesUint(uint64(item.Key))
+	if err = binary.Write(buf, binary.BigEndian, minBytes); err != nil {
+		return nil, err
+	}
+
+	switch v := item.Value.(type) {
+	case int, int8, int16, int32, int64:
+		vi := int64(reflect.ValueOf(v).Int())
+		valueType, minBytes = minimalBytesInt(vi)
+		if err = binary.Write(buf, binary.BigEndian, minBytes); err != nil {
+			return nil, err
+		}
+	case uint, uint8, uint16, uint32, uint64:
+		vu := reflect.ValueOf(v).Uint()
+		valueType, minBytes = minimalBytesUint(vu)
+		if err = binary.Write(buf, binary.BigEndian, minBytes); err != nil {
+			return nil, err
+		}
+	case string:
+		valueType = ndpi_serialization_string
+		strLen := uint16(len(v))
+		if err = binary.Write(buf, binary.BigEndian, strLen); err != nil {
+			return nil, err
+		}
+		if _, err = buf.Write([]byte(v)); err != nil {
+			return nil, err
+		}
+
+	default:
+		return nil, fmt.Errorf("unknown value type for key: %s. Type was: %T",
+			netflow.NFv9TypeToString(uint16(item.Key)), item.Value)
+	}
+
+	// Write types byte first
+	bytes := buf.Bytes()
+	ret := append([]byte{(keyType << 4) | (valueType & 0x0F)}, bytes...)
+	return ret, nil
+}
+
+func SerializeTlvRecord(items []NdpiItem) ([]byte, error) {
+	var out bytes.Buffer
+	log.Tracef("Starting TLV serializing for flow.")
+	// ndpi_init_serializer_ll() in ndpi_serializer.c writes out 0x01 0x01 at the beginning of each TLV record.
+	out.WriteByte(0x01)
+	out.WriteByte(0x01)
+
+	for _, it := range items {
+		log.Tracef("Serializing item: %s[%d]=%v\n",
+			netflow.NFv9TypeToString(it.Key), it.Key, it.Value)
+		b, err := SerializeTlvItem(it)
+
+		if err != nil {
+			log.Errorf("Unable to serialize an item: %s", err.Error())
+			return nil, err
+		}
+		log.Tracef("Serialized item bytes\n%s", hex.Dump(b))
+		out.Write(b)
+	}
+	out.WriteByte(ndpi_serialization_end_of_record)
+
+	log.Tracef("Done with TLV serializing for flow.")
+	return out.Bytes(), nil
+}

--- a/cmd/zmq.go
+++ b/cmd/zmq.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cloudflare/goflow/v3/decoders/netflow"
 	flowmessage "github.com/cloudflare/goflow/v3/pb"
+
 	// nolint SA1019 the new google.golang.org/protobuf/proto package is not backwards compatible
 	"github.com/golang/protobuf/proto"
 	zmq "github.com/pebbe/zmq4"
@@ -46,6 +47,8 @@ func StartZmqProducer() (*ZmqState, error) {
 	serialize := "json"
 	if rctx.cli.Protobuf {
 		serialize = "pbuf"
+	} else if rctx.cli.TLV {
+		serialize = "tlv"
 	}
 
 	log.Infof("Started ZMQ listener on: %s", rctx.cli.ListenZmq)
@@ -66,11 +69,13 @@ func StartZmqProducer() (*ZmqState, error) {
  * include/ntop_typedefs.h, include/ntop_defines.h & src/ZMQCollectorInterface.cpp from
  * https://github.com/ntop/ntopng
  */
-const ZMQ_MSG_VERSION = 2 // ntopng message version 2
-const ZMQ_TOPIC = "flow"  // ntopng only really cares about the first character!
+const ZMQ_MSG_VERSION_OLD = 2 // ntopng message version 2 for ntopng less than v6.4
+const ZMQ_MSG_VERSION_TLV = 3 // ntop message version for TLV for ntopng v6.4 and later.
+const ZMQ_TOPIC = "flow"      // ntopng only really cares about the first character!
 
 var MessageId uint32 = 0 // Every ZMQ message we send should have a uniq ID
 
+// This is zmq_msg_hdr_v1 from ntop_typedefs.h May want to update to zmq_msg_hdr_v2?
 type ZmqHeader struct {
 	url       string
 	version   uint8
@@ -80,9 +85,13 @@ type ZmqHeader struct {
 }
 
 func (zs *ZmqState) NewZmqHeader(length uint16) *ZmqHeader {
+	var version uint8 = ZMQ_MSG_VERSION_TLV
+	if !rctx.cli.TLV {
+		version = ZMQ_MSG_VERSION_OLD
+	}
 	z := &ZmqHeader{
 		url:       ZMQ_TOPIC,
-		version:   ZMQ_MSG_VERSION,
+		version:   version,
 		source_id: uint8(rctx.cli.SourceId),
 		length:    length,
 		msg_id:    MessageId,
@@ -262,6 +271,132 @@ func (zs *ZmqState) toJSON(flowMessage *flowmessage.FlowMessage) ([]byte, error)
 	return jdata, nil
 }
 
+/*
+ * Converts a FlowMessage to ntop's TLV format
+ */
+func (zs *ZmqState) toTLV(flowMessage *flowmessage.FlowMessage) ([]byte, error) {
+	ip6 := make(net.IP, net.IPv6len)
+	ip4 := make(net.IP, net.IPv4len)
+	hwaddr := make(net.HardwareAddr, 6)
+	_hwaddr := make([]byte, binary.MaxVarintLen64)
+	var icmp_type uint16
+
+	// Overall approach is to make an slice of NdpiItems, then serialize them all to make a
+	// record that can be published via ZMQ
+
+	// Stats + direction
+	items := []NdpiItem{{Key: netflow.NFV9_FIELD_DIRECTION, Value: flowMessage.FlowDirection}}
+	if flowMessage.FlowDirection == 0 {
+		// ingress == 0
+		items = append(items,
+			NdpiItem{Key: netflow.NFV9_FIELD_IN_BYTES, Value: flowMessage.Bytes},
+			NdpiItem{Key: netflow.NFV9_FIELD_IN_PKTS, Value: flowMessage.Packets},
+		)
+	} else {
+		// egress == 1
+		items = append(items,
+			NdpiItem{Key: netflow.NFV9_FIELD_OUT_BYTES, Value: flowMessage.Bytes},
+			NdpiItem{Key: netflow.NFV9_FIELD_OUT_PKTS, Value: flowMessage.Packets},
+		)
+	}
+	items = append(items,
+		NdpiItem{Key: netflow.NFV9_FIELD_FIRST_SWITCHED, Value: flowMessage.TimeFlowStart},
+		NdpiItem{Key: netflow.NFV9_FIELD_LAST_SWITCHED, Value: flowMessage.TimeFlowEnd},
+	)
+
+	items = append(items,
+		// L4
+		NdpiItem{Key: netflow.NFV9_FIELD_PROTOCOL, Value: flowMessage.Proto},
+		NdpiItem{Key: netflow.NFV9_FIELD_L4_SRC_PORT, Value: flowMessage.SrcPort},
+		NdpiItem{Key: netflow.NFV9_FIELD_L4_DST_PORT, Value: flowMessage.DstPort},
+		// Network
+		NdpiItem{Key: netflow.NFV9_FIELD_SRC_AS, Value: flowMessage.SrcAS},
+		NdpiItem{Key: netflow.NFV9_FIELD_DST_AS, Value: flowMessage.DstAS},
+
+		// Interfaces
+		NdpiItem{Key: netflow.NFV9_FIELD_INPUT_SNMP, Value: flowMessage.InIf},
+		NdpiItem{Key: netflow.NFV9_FIELD_OUTPUT_SNMP, Value: flowMessage.OutIf},
+		NdpiItem{Key: netflow.NFV9_FIELD_FORWARDING_STATUS, Value: flowMessage.ForwardingStatus},
+		NdpiItem{Key: netflow.NFV9_FIELD_SRC_TOS, Value: flowMessage.IPTos},
+		NdpiItem{Key: netflow.NFV9_FIELD_TCP_FLAGS, Value: flowMessage.TCPFlags},
+		NdpiItem{Key: netflow.NFV9_FIELD_MIN_TTL, Value: flowMessage.IPTTL},
+	)
+
+	// IP
+	if flowMessage.Etype == 0x800 {
+		// IPv4
+		items = append(items,
+			NdpiItem{Key: netflow.NFV9_FIELD_IP_PROTOCOL_VERSION, Value: 4},
+			NdpiItem{Key: netflow.NFV9_FIELD_IPV4_SRC_PREFIX, Value: flowMessage.SrcNet},
+			NdpiItem{Key: netflow.NFV9_FIELD_IPV4_DST_PREFIX, Value: flowMessage.DstNet},
+			NdpiItem{Key: netflow.NFV9_FIELD_IPV4_IDENT, Value: flowMessage.FragmentId},
+			NdpiItem{Key: netflow.NFV9_FIELD_FRAGMENT_OFFSET, Value: flowMessage.FragmentOffset},
+			NdpiItem{Key: netflow.NFV9_FIELD_IPV6_SRC_MASK, Value: flowMessage.SrcNet},
+			NdpiItem{Key: netflow.NFV9_FIELD_IPV6_DST_MASK, Value: flowMessage.DstNet},
+		)
+		copy(ip4, flowMessage.SrcAddr)
+		items = append(items, NdpiItem{Key: netflow.NFV9_FIELD_IPV4_SRC_ADDR, Value: ip4.String()})
+		copy(ip4, flowMessage.DstAddr)
+		items = append(items, NdpiItem{Key: netflow.NFV9_FIELD_IPV4_DST_ADDR, Value: ip4.String()})
+		copy(ip4, flowMessage.NextHop)
+		items = append(items, NdpiItem{Key: netflow.NFV9_FIELD_IPV4_NEXT_HOP, Value: ip4.String()})
+
+	} else {
+		// 0x86dd IPv6
+		items = append(items,
+			NdpiItem{Key: netflow.NFV9_FIELD_IP_PROTOCOL_VERSION, Value: 6},
+			NdpiItem{Key: netflow.NFV9_FIELD_IPV6_SRC_MASK, Value: flowMessage.SrcNet},
+			NdpiItem{Key: netflow.NFV9_FIELD_IPV6_DST_MASK, Value: flowMessage.DstNet},
+			NdpiItem{Key: netflow.NFV9_FIELD_IPV6_FLOW_LABEL, Value: flowMessage.IPv6FlowLabel},
+		)
+		copy(ip6, flowMessage.SrcAddr)
+		items = append(items, NdpiItem{Key: netflow.NFV9_FIELD_IPV6_SRC_ADDR, Value: ip6.String()})
+		copy(ip6, flowMessage.DstAddr)
+		items = append(items, NdpiItem{Key: netflow.NFV9_FIELD_IPV6_DST_ADDR, Value: ip6.String()})
+		copy(ip6, flowMessage.NextHop)
+		items = append(items, NdpiItem{Key: netflow.NFV9_FIELD_IPV6_NEXT_HOP, Value: ip6.String()})
+	}
+
+	// ICMP
+	icmp_type = uint16((uint16(flowMessage.IcmpType) << 8) + uint16(flowMessage.IcmpCode))
+	items = append(items, NdpiItem{Key: netflow.NFV9_FIELD_ICMP_TYPE, Value: icmp_type})
+
+	// MAC
+	binary.PutUvarint(_hwaddr, flowMessage.DstMac)
+	for i := 0; i < 6; i++ {
+		hwaddr[i] = _hwaddr[i]
+	}
+	items = append(items, NdpiItem{Key: netflow.NFV9_FIELD_IN_DST_MAC, Value: hwaddr.String()})
+	binary.PutUvarint(_hwaddr, flowMessage.SrcMac)
+	for i := 0; i < 6; i++ {
+		hwaddr[i] = _hwaddr[i]
+	}
+	items = append(items, NdpiItem{Key: netflow.NFV9_FIELD_OUT_SRC_MAC, Value: hwaddr.String()})
+
+	// VLAN
+	items = append(items,
+		NdpiItem{Key: netflow.NFV9_FIELD_SRC_VLAN, Value: flowMessage.SrcVlan},
+		NdpiItem{Key: netflow.NFV9_FIELD_DST_VLAN, Value: flowMessage.DstVlan},
+	)
+
+	// Flow Exporter IP
+	if len(flowMessage.SamplerAddress) == 4 {
+		copy(ip4, flowMessage.SamplerAddress)
+		items = append(items, NdpiItem{Key: netflow.IPFIX_FIELD_exporterIPv4Address, Value: ip4.String()})
+	} else if len(flowMessage.SamplerAddress) == 16 {
+		copy(ip6, flowMessage.SamplerAddress)
+		items = append(items, NdpiItem{Key: netflow.IPFIX_FIELD_exporterIPv6Address, Value: ip6.String()})
+	}
+
+	// Serialize and make a flow record.
+	tlvbuf, err := SerializeTlvRecord(items)
+	if err != nil {
+		return tlvbuf, err
+	}
+
+	return tlvbuf, nil
+}
+
 func (zs *ZmqState) Publish(msgs []*flowmessage.FlowMessage) {
 	for _, msg := range msgs {
 		zs.SendZmqMessage(msg)
@@ -274,8 +409,10 @@ func (zs *ZmqState) SendZmqMessage(flowMessage *flowmessage.FlowMessage) {
 
 	if zs.serialize == "pbuf" {
 		msg, err = proto.Marshal(flowMessage)
-	} else {
+	} else if zs.serialize == "json" {
 		msg, err = zs.toJSON(flowMessage)
+	} else {
+		msg, err = zs.toTLV(flowMessage)
 	}
 
 	if err != nil {
@@ -309,13 +446,15 @@ func (zs *ZmqState) SendZmqMessage(flowMessage *flowmessage.FlowMessage) {
 		return
 	}
 
-	if zs.serialize == "json" {
+	if zs.serialize == "pbuf" {
+		log.Debugf("sent %d bytes of pbuf:\n%s", msg_len, hex.Dump(msg))
+	} else if zs.serialize == "json" {
 		if zs.compress {
 			log.Debugf("sent %d bytes of zlib json:\n%s", msg_len, hex.Dump(msg))
 		} else {
 			log.Debugf("sent %d bytes of json: %s", msg_len, string(msg))
 		}
 	} else {
-		log.Debugf("sent %d bytes of pbuf:\n%s", msg_len, hex.Dump(msg))
+		log.Debugf("sent %d bytes of ntop tlv:\n%s", msg_len, hex.Dump(msg))
 	}
 }


### PR DESCRIPTION
As of ntop v6.4, the JSON format is no longer accepted for community mode:  See issue #89 

This commit adds an --tlv commandline parameter that will be accepted by ntopng as of v6.4

The format is "interesting" so I put it all in its own file. See that file for details on the format.

TESTING:
* Running netflow2ng on Debian 13, router sending it Netflow v9
* ntopng v6.4 (installed from packages) on different host.
* Confirmed ntop was in community mode and that I could see recent flows that matched my network activity.

FUTURE WORK:
* Test against top-of-tree ntopng
* Update the ZmqHeader struct to the most recent one in the ntopng code, in an effort to stay ahead of any more deprecation.