### PR TITLE
Add sFlow support, sampling tracking, dedup, and multi-endpoint ZMQ fan-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,365 @@
 # netflow2ng
-NetFlow v9 collector for [ntopng](https://www.ntop.org/products/traffic-analysis/ntop/)
+
+High-throughput NetFlow v9/IPFIX/sFlow collector for [ntopng](https://www.ntop.org/products/traffic-analysis/ntop/)
 
 [![Tests](https://github.com/synfinatic/netflow2ng/actions/workflows/tests.yml/badge.svg)](https://github.com/synfinatic/netflow2ng/actions/workflows/tests.yml)
 [![codeql-analysis.yml](https://github.com/synfinatic/netflow2ng/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/synfinatic/netflow2ng/actions/workflows/codeql-analysis.yml)
 [![golangci-lint](https://github.com/synfinatic/netflow2ng/actions/workflows/golangci-lint.yaml/badge.svg)](https://github.com/synfinatic/netflow2ng/actions/workflows/golangci-lint.yaml)
 
-### TL;DR
+## Overview
 
-ntopng is a free/commercial NetFlow/sFlow analysis console suitible for a
-variety of use cases.  However, if you want to collect NetFlow or sFlow
-data and load that into ntopng you currently have no choice but to spend
-199Euro on [nProbe](https://www.ntop.org/products/netflow/nprobe/) which
-in my case is more expensive than the
-[Ubiquiti USG](https://www.ui.com/unifi-routing/usg/) that I wanted to
-collect NetFlow stats from.
+ntopng is a free/commercial network traffic analysis console suitable for a variety of use cases. However, if you want to collect NetFlow, IPFIX, or sFlow data and load it into ntopng, you typically need [nProbe](https://www.ntop.org/products/netflow/nprobe/) which may be cost-prohibitive for home/SOHO use.
 
-Hence, I created netflow2ng.
+**netflow2ng** provides a high-performance, open-source alternative optimized for:
+- Predictable but high-bandwidth environments (cameras, NVRs, intercoms, switches)
+- Collector mode with ZMQ publisher interoperability with ntopng
+- Per-exporter sampling rate tracking and upscaling
+- Multi-endpoint ZMQ fan-out for scaling
 
-### Installing
+## Features
 
-##### Build From Source
- 1. Make sure you have a recent version of go.  I used 1.14.2.   Older versions
-    may have problems.
- 1. `git clone https://github.com/synfinatic/netflow2ng.git`
- 1. `cd netflow2ng`
- 1. `make`
- 1. The binary should now be in the `dist` directory.  Copy it somewhere
-    appropriate and create the necessary startup script(s).
+### Protocol Support
+- **NetFlow v9** - Full template-based support
+- **IPFIX (NetFlow v10)** - Full support including options templates
+- **sFlow v5** - Native packet sampling support
 
-##### Install via Docker
+### Performance Features
+- **Fixed worker pool** with bounded queue (no goroutine per packet)
+- **sync.Pool** for byte buffers to reduce GC pressure
+- **Ring buffer** for efficient packet queuing
+- **Metrics** for queue depth, drops, and per-exporter throughput
 
- 1. Pull the repository using `git clone https://github.com/synfinatic/netflow2ng.git`.
- 1. Use the optional [docker-compose.yaml](docker-compose.yaml) file with `docker compose up`.
+### Sampling & Accuracy
+- **Automatic sampling rate detection** from:
+  - IPFIX options templates
+  - sFlow datagram headers
+- **Configurable upscaling** of bytes/packets before sending to ntopng
+- **Manual rate override** for exporters that pre-scale
 
- **Important**: When using Docker, you must use host networking due to NAT causing the source
- port to change for inbound Netflow packets which breaks `netflow2ng`.
+### Flow Relay / Fan-out
+- **Multi-endpoint ZMQ** publishing to multiple ntopng instances
+- **Hash-based distribution** (exporter + 5-tuple) for flow affinity
+- **Round-robin distribution** for load balancing
 
-### Configuration
+### Deduplication
+- **Per-exporter dedup cache** with configurable TTL and size bounds
+- **Heuristics** to avoid false positives on long-lived flows
 
- 1. For a list of configuration arguments, run `netflow2ng -h`. As of v0.1.1, netflow2ng
-    defaults to the ntopng TLV format instead of JSON. If you want to use JSON, you must
-    use it with `ntopng` v6.3 or earlier.
- 1. Configure your network device(s) to send NetFlow stats to netflow2ng
- 1. Configure your [ntopng](https://www.ntop.org/products/traffic-analysis/ntop/)
-    service to read from netflow2ng: `ntopng -i tcp://192.168.1.1:5556` where
-    "192.168.1.1" is the IP address of your netflow2ng server.
+## Installation
 
-### Features
+### Build From Source
 
- * Collect NetFlow v9 stats from one or more probes
- * Run a ZMQ Publisher for ntopng to collect metrics from
- * Prometheus metrics
- * NetFlow Templates available via /templates HTTP endpoint
+```bash
+# Ensure you have Go 1.23+ and libzmq development files
+apt-get install libzmq3-dev  # Debian/Ubuntu
+brew install zeromq          # macOS
 
-### Ports
+git clone https://github.com/synfinatic/netflow2ng.git
+cd netflow2ng
+make
+# Binary will be in dist/
+```
 
-By default, netflow2ng listens on all addresses on the following ports. This can be changed via configuration arguments.
- * NetFlow/IPFIX: 2055
- * ZMQ connections (TCP): 5556
- * Metrics: 8080
+### Docker
 
-### NetFlow v9 Support
+```bash
+git clone https://github.com/synfinatic/netflow2ng.git
+cd netflow2ng
+docker compose up
+```
 
-netflow2ng utilizes [goflow2](https://github.com/netsampler/goflow2) for NetFlow
-decoding.  For more information on what NetFlow fields are supported in
-netflow2ng, please read the goflow docs.
+**Important**: When using Docker, you must use host networking due to NAT causing the source port to change for inbound flow packets.
 
-### sFlow/IPFIX/etc support?
+## Configuration
 
-In theory, adding sFlow/IPFIX/NetFlow v5 support should be pretty trivial, but
-isn't something I plan on doing due to lack of hardware for testing/need.
+### Command Line Options
 
-### How is netflow2ng different from nProbe?
+```
+Usage: netflow2ng [flags]
 
- * Not 199Euro
- * Doesn't support any probe features (sniffing traffic directly)
- * Can't write stats to MySQL/disk or act as a NetFlow proxy
- * Not tested with lots of probes or on 10Gbit networks
- * Targeted for Home/SOHO use.
- * No commercial support, etc.
- * May not support the latest versions/features of ntopng
- * Written in GoLang instead of C/C++
+High-throughput NetFlow v9/IPFIX/sFlow collector for ntopng
+
+Flags:
+  -h, --help                      Show context-sensitive help.
+
+NetFlow/IPFIX Configuration:
+  -a, --listen=0.0.0.0:2055       NetFlow/IPFIX listen address:port
+      --reuse                     Enable SO_REUSEPORT for NetFlow/IPFIX listen port
+  -w, --workers=2                 Number of NetFlow workers
+
+sFlow Configuration:
+      --sflow-listen=ADDRESS      sFlow listen address:port (empty to disable)
+      --sflow-workers=2           Number of sFlow workers
+
+Metrics/Health:
+  -m, --metrics=0.0.0.0:8080      Metrics listen address
+
+ZMQ Configuration:
+  -z, --listen-zmq="tcp://*:5556" ZMQ bind address(es), comma-separated for fan-out
+      --fanout-strategy="hash"    ZMQ fan-out strategy [hash|round-robin]
+      --topic="flow"              ZMQ Topic
+      --source-id=0               NetFlow SourceId (0-255)
+  -f, --format="tlv"              Output format [tlv|json|jcompress|proto]
+
+Sampling Configuration:
+      --disable-upscaling         Disable sampling rate upscaling (use when exporters pre-scale)
+      --default-sample-rate=1     Default sampling rate when not reported by exporter
+
+Deduplication Configuration:
+      --dedup-enabled             Enable flow deduplication
+      --dedup-max-size=100000     Maximum dedup cache size
+      --dedup-ttl=60s             Dedup cache entry TTL
+
+Queue Configuration:
+      --queue-size=1000000        Packet queue size
+
+Logging:
+  -l, --log-level="info"          Log level [error|warn|info|debug|trace]
+      --log-format="default"      Log format [default|json]
+
+  -v, --version                   Print version and copyright info
+```
+
+### Examples
+
+#### Basic Usage (NetFlow/IPFIX only)
+
+```bash
+netflow2ng -a 0.0.0.0:2055 -z tcp://*:5556
+```
+
+#### With sFlow Support
+
+```bash
+netflow2ng -a 0.0.0.0:2055 --sflow-listen 0.0.0.0:6343 -z tcp://*:5556
+```
+
+#### Multi-Endpoint Fan-out (Hash-based)
+
+Distribute flows across multiple ntopng instances with flow affinity:
+
+```bash
+netflow2ng -a 0.0.0.0:2055 \
+  -z "tcp://*:5556,tcp://*:5557,tcp://*:5558" \
+  --fanout-strategy hash
+```
+
+#### Multi-Endpoint Fan-out (Round-Robin)
+
+Load balance across ntopng instances:
+
+```bash
+netflow2ng -a 0.0.0.0:2055 \
+  -z "tcp://*:5556,tcp://*:5557" \
+  --fanout-strategy round-robin
+```
+
+#### With Sampling Upscaling Disabled
+
+Use when your exporters already account for sampling in reported values:
+
+```bash
+netflow2ng -a 0.0.0.0:2055 --disable-upscaling
+```
+
+#### With Deduplication Enabled
+
+Enable flow deduplication to suppress duplicate flow records:
+
+```bash
+netflow2ng -a 0.0.0.0:2055 \
+  --dedup-enabled \
+  --dedup-max-size 200000 \
+  --dedup-ttl 120s
+```
+
+#### High-Throughput Configuration
+
+For high-volume environments:
+
+```bash
+netflow2ng -a 0.0.0.0:2055 \
+  --sflow-listen 0.0.0.0:6343 \
+  -w 8 \
+  --sflow-workers 4 \
+  --queue-size 2000000 \
+  -z "tcp://*:5556,tcp://*:5557" \
+  --fanout-strategy hash \
+  --dedup-enabled \
+  --dedup-max-size 500000
+```
+
+### ntopng Configuration
+
+Configure ntopng to subscribe to netflow2ng:
+
+```bash
+ntopng -i tcp://192.168.1.1:5556
+```
+
+For multi-endpoint setups, run multiple ntopng instances or use ntopng's multi-interface support:
+
+```bash
+ntopng -i tcp://192.168.1.1:5556 -i tcp://192.168.1.1:5557
+```
+
+## HTTP Endpoints
+
+netflow2ng exposes several HTTP endpoints on the metrics port (default 8080):
+
+| Endpoint | Description |
+|----------|-------------|
+| `/__health` | Health check (503 until collecting, 200 when ready) |
+| `/metrics` | Prometheus metrics |
+| `/templates` | NetFlow/IPFIX template cache (JSON) |
+| `/sampling` | Per-exporter sampling rate information (JSON) |
+| `/dedup` | Deduplication cache statistics (JSON, if enabled) |
+
+## Prometheus Metrics
+
+netflow2ng exports comprehensive Prometheus metrics:
+
+### Queue Metrics
+- `netflow2ng_packets_received_total` - Total packets received
+- `netflow2ng_packets_processed_total` - Total packets processed
+- `netflow2ng_packets_dropped_total` - Packets dropped due to queue overflow
+- `netflow2ng_queue_depth` - Current queue depth
+- `netflow2ng_workers_busy` - Number of workers currently processing
+
+### Exporter Metrics
+- `netflow2ng_exporter_packets_received_total{exporter_ip,source_id}` - Per-exporter packets
+- `netflow2ng_exporter_bytes_received_total{exporter_ip,source_id}` - Per-exporter bytes
+- `netflow2ng_exporter_flows_processed_total{exporter_ip,source_id}` - Per-exporter flows
+
+### Sampling Metrics
+- `netflow2ng_sampling_rate{exporter_ip,observation_domain,source}` - Current sampling rate
+- `netflow2ng_sampling_scaled_bytes_total{exporter_ip}` - Bytes added by upscaling
+- `netflow2ng_sampling_scaled_packets_total{exporter_ip}` - Packets added by upscaling
+
+### ZMQ Metrics
+- `netflow2ng_zmq_messages_sent_total{endpoint}` - Messages sent per endpoint
+- `netflow2ng_zmq_bytes_sent_total{endpoint}` - Bytes sent per endpoint
+- `netflow2ng_zmq_errors_total{endpoint,error_type}` - Errors per endpoint
+- `netflow2ng_zmq_endpoints_active` - Number of active endpoints
+
+### Deduplication Metrics (when enabled)
+- `netflow2ng_dedup_cache_hits_total` - Cache hits (potential duplicates)
+- `netflow2ng_dedup_cache_misses_total` - Cache misses (new flows)
+- `netflow2ng_dedup_duplicates_total` - Actual duplicates suppressed
+- `netflow2ng_dedup_cache_size` - Current cache size
+- `netflow2ng_dedup_evictions_total` - Evictions due to size limit
+- `netflow2ng_dedup_expired_evictions_total` - Evictions due to TTL
+
+### sFlow Metrics (when enabled)
+- `netflow2ng_sflow_datagrams_received_total` - sFlow datagrams received
+- `netflow2ng_sflow_samples_decoded_total` - sFlow samples decoded
+- `netflow2ng_sflow_flows_produced_total` - Flow messages produced
+- `netflow2ng_sflow_decode_errors_total` - Decode errors
+
+## Architecture
+
+```
+┌─────────────────┐     ┌─────────────────┐
+│ NetFlow/IPFIX   │     │     sFlow       │
+│   Exporters     │     │   Exporters     │
+└────────┬────────┘     └────────┬────────┘
+         │                       │
+         ▼                       ▼
+┌─────────────────┐     ┌─────────────────┐
+│  UDP Receiver   │     │  UDP Receiver   │
+│  (port 2055)    │     │  (port 6343)    │
+└────────┬────────┘     └────────┬────────┘
+         │                       │
+         ▼                       ▼
+┌─────────────────┐     ┌─────────────────┐
+│   Ring Buffer   │     │   Ring Buffer   │
+└────────┬────────┘     └────────┬────────┘
+         │                       │
+         ▼                       ▼
+┌─────────────────┐     ┌─────────────────┐
+│  Worker Pool    │     │  Worker Pool    │
+│  (decode/prod)  │     │  (decode/prod)  │
+└────────┬────────┘     └────────┬────────┘
+         │                       │
+         └───────────┬───────────┘
+                     │
+                     ▼
+         ┌─────────────────────┐
+         │  Sampling Tracker   │
+         │  (upscale if enabled)│
+         └──────────┬──────────┘
+                    │
+                    ▼
+         ┌─────────────────────┐
+         │  Dedup Cache        │
+         │  (if enabled)       │
+         └──────────┬──────────┘
+                    │
+                    ▼
+         ┌─────────────────────┐
+         │  Formatter          │
+         │  (TLV/JSON)         │
+         └──────────┬──────────┘
+                    │
+                    ▼
+         ┌─────────────────────┐
+         │  ZMQ Publisher      │
+         │  (fan-out)          │
+         └──────────┬──────────┘
+                    │
+         ┌──────────┼──────────┐
+         ▼          ▼          ▼
+    ┌────────┐ ┌────────┐ ┌────────┐
+    │ntopng 1│ │ntopng 2│ │ntopng 3│
+    └────────┘ └────────┘ └────────┘
+```
+
+## Deduplication Heuristics
+
+The deduplication cache uses several heuristics to avoid false positives:
+
+1. **Flow identification**: Flows are keyed by exporter IP + 5-tuple (src/dst IP, ports, protocol)
+2. **Update detection**: Flows with increased bytes/packets are not considered duplicates
+3. **Sequence tracking**: Flows with advancing sequence numbers pass through
+4. **Long-lived flow handling**: Periodic updates for flows active longer than TTL are allowed
+
+This ensures that legitimate flow updates are not suppressed while true duplicates (same packet reported multiple times) are filtered.
+
+## Ports
+
+Default listening ports (configurable via flags):
+
+| Port | Protocol | Description |
+|------|----------|-------------|
+| 2055 | UDP | NetFlow v9/IPFIX |
+| 6343 | UDP | sFlow (when enabled) |
+| 5556 | TCP | ZMQ Publisher |
+| 8080 | TCP | Metrics/Health/Templates |
+
+## Differences from nProbe
+
+| Feature | netflow2ng | nProbe |
+|---------|-----------|--------|
+| Price | Free | 199 Euro |
+| Probe mode | No | Yes |
+| Collector mode | Yes | Yes |
+| NetFlow v5 | No | Yes |
+| NetFlow v9 | Yes | Yes |
+| IPFIX | Yes | Yes |
+| sFlow | Yes | Yes |
+| Multi-endpoint fan-out | Yes | Via configuration |
+| Sampling upscaling | Yes | Yes |
+| Deduplication | Yes | Yes |
+| MySQL/disk export | No | Yes |
+| Commercial support | No | Yes |
+
+## Contributing
+
+Contributions are welcome! Please ensure:
+1. Code passes `go vet` and `golangci-lint`
+2. New features include tests
+3. Documentation is updated
+
+## License
+
+See [LICENSE](LICENSE) file.

--- a/collector/buffer.go
+++ b/collector/buffer.go
@@ -1,0 +1,103 @@
+package collector
+
+import (
+	"sync"
+)
+
+// ByteBufferPool provides a pool of reusable byte buffers to reduce GC pressure
+type ByteBufferPool struct {
+	pool       sync.Pool
+	bufferSize int
+}
+
+// NewByteBufferPool creates a new byte buffer pool with the specified buffer size
+func NewByteBufferPool(bufferSize int) *ByteBufferPool {
+	return &ByteBufferPool{
+		bufferSize: bufferSize,
+		pool: sync.Pool{
+			New: func() interface{} {
+				return make([]byte, bufferSize)
+			},
+		},
+	}
+}
+
+// Get retrieves a buffer from the pool
+func (p *ByteBufferPool) Get() []byte {
+	return p.pool.Get().([]byte)
+}
+
+// Put returns a buffer to the pool
+func (p *ByteBufferPool) Put(buf []byte) {
+	// Only return buffers of the correct capacity
+	bufCap := cap(buf)
+	if bufCap >= p.bufferSize {
+		// Extend slice to full capacity for clearing and returning
+		fullBuf := buf[:bufCap]
+		// Clear only up to bufferSize
+		for i := 0; i < p.bufferSize; i++ {
+			fullBuf[i] = 0
+		}
+		p.pool.Put(fullBuf[:p.bufferSize])
+	}
+}
+
+// WorkItemPool provides a pool of reusable PacketWork objects
+type WorkItemPool struct {
+	pool sync.Pool
+}
+
+// NewWorkItemPool creates a new work item pool
+func NewWorkItemPool() *WorkItemPool {
+	return &WorkItemPool{
+		pool: sync.Pool{
+			New: func() interface{} {
+				return &PacketWork{}
+			},
+		},
+	}
+}
+
+// Get retrieves a work item from the pool
+func (p *WorkItemPool) Get() *PacketWork {
+	return p.pool.Get().(*PacketWork)
+}
+
+// Put returns a work item to the pool
+func (p *WorkItemPool) Put(work *PacketWork) {
+	// Clear the work item before returning
+	work.Data = nil
+	work.Length = 0
+	work.RemoteAddr = nil
+	p.pool.Put(work)
+}
+
+// FlowBufferPool provides a pool of reusable flow message buffers
+type FlowBufferPool struct {
+	pool       sync.Pool
+	bufferSize int
+}
+
+// NewFlowBufferPool creates a new flow buffer pool
+func NewFlowBufferPool(bufferSize int) *FlowBufferPool {
+	return &FlowBufferPool{
+		bufferSize: bufferSize,
+		pool: sync.Pool{
+			New: func() interface{} {
+				return make([]byte, 0, bufferSize)
+			},
+		},
+	}
+}
+
+// Get retrieves a flow buffer from the pool
+func (p *FlowBufferPool) Get() []byte {
+	return p.pool.Get().([]byte)[:0]
+}
+
+// Put returns a flow buffer to the pool
+func (p *FlowBufferPool) Put(buf []byte) {
+	if cap(buf) >= p.bufferSize {
+		p.pool.Put(buf[:0])
+	}
+}

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -1,0 +1,237 @@
+package collector
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// ExporterKey uniquely identifies a flow exporter
+type ExporterKey struct {
+	IP       string
+	SourceID uint32
+}
+
+// ExporterStats holds statistics for a single exporter
+type ExporterStats struct {
+	key             ExporterKey
+	packetsReceived atomic.Uint64
+	bytesReceived   atomic.Uint64
+	flowsProcessed  atomic.Uint64
+	lastSeen        atomic.Int64 // Unix timestamp
+	errors          atomic.Uint64
+}
+
+// NewExporterStats creates a new exporter stats tracker
+func NewExporterStats(key ExporterKey) *ExporterStats {
+	return &ExporterStats{
+		key: key,
+	}
+}
+
+// RecordPacket records a received packet from this exporter
+func (e *ExporterStats) RecordPacket(bytes int) {
+	e.packetsReceived.Add(1)
+	e.bytesReceived.Add(uint64(bytes))
+	e.lastSeen.Store(time.Now().Unix())
+}
+
+// RecordFlows records processed flows from this exporter
+func (e *ExporterStats) RecordFlows(count int) {
+	e.flowsProcessed.Add(uint64(count))
+}
+
+// RecordError records an error from this exporter
+func (e *ExporterStats) RecordError() {
+	e.errors.Add(1)
+}
+
+// GetStats returns current statistics
+func (e *ExporterStats) GetStats() (packets, bytes, flows, errors uint64, lastSeen time.Time) {
+	return e.packetsReceived.Load(),
+		e.bytesReceived.Load(),
+		e.flowsProcessed.Load(),
+		e.errors.Load(),
+		time.Unix(e.lastSeen.Load(), 0)
+}
+
+// ExporterRegistry tracks all known exporters and their statistics
+type ExporterRegistry struct {
+	exporters map[ExporterKey]*ExporterStats
+	mu        sync.RWMutex
+	metrics   *ExporterMetrics
+}
+
+// ExporterMetrics holds prometheus metrics for exporter tracking
+type ExporterMetrics struct {
+	PacketsReceived *prometheus.CounterVec
+	BytesReceived   *prometheus.CounterVec
+	FlowsProcessed  *prometheus.CounterVec
+	Errors          *prometheus.CounterVec
+	LastSeen        *prometheus.GaugeVec
+	ActiveExporters prometheus.Gauge
+}
+
+// NewExporterMetrics creates prometheus metrics for exporter tracking
+func NewExporterMetrics(namespace string) *ExporterMetrics {
+	return &ExporterMetrics{
+		PacketsReceived: promauto.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "exporter",
+			Name:      "packets_received_total",
+			Help:      "Total packets received per exporter",
+		}, []string{"exporter_ip", "source_id"}),
+		BytesReceived: promauto.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "exporter",
+			Name:      "bytes_received_total",
+			Help:      "Total bytes received per exporter",
+		}, []string{"exporter_ip", "source_id"}),
+		FlowsProcessed: promauto.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "exporter",
+			Name:      "flows_processed_total",
+			Help:      "Total flows processed per exporter",
+		}, []string{"exporter_ip", "source_id"}),
+		Errors: promauto.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "exporter",
+			Name:      "errors_total",
+			Help:      "Total errors per exporter",
+		}, []string{"exporter_ip", "source_id"}),
+		LastSeen: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "exporter",
+			Name:      "last_seen_timestamp",
+			Help:      "Unix timestamp of last packet from exporter",
+		}, []string{"exporter_ip", "source_id"}),
+		ActiveExporters: promauto.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "exporter",
+			Name:      "active_count",
+			Help:      "Number of active exporters",
+		}),
+	}
+}
+
+// NewExporterRegistry creates a new exporter registry
+func NewExporterRegistry(metrics *ExporterMetrics) *ExporterRegistry {
+	return &ExporterRegistry{
+		exporters: make(map[ExporterKey]*ExporterStats),
+		metrics:   metrics,
+	}
+}
+
+// GetOrCreate returns an existing exporter stats or creates a new one
+func (r *ExporterRegistry) GetOrCreate(ip net.IP, sourceID uint32) *ExporterStats {
+	key := ExporterKey{
+		IP:       ip.String(),
+		SourceID: sourceID,
+	}
+
+	r.mu.RLock()
+	if stats, ok := r.exporters[key]; ok {
+		r.mu.RUnlock()
+		return stats
+	}
+	r.mu.RUnlock()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if stats, ok := r.exporters[key]; ok {
+		return stats
+	}
+
+	stats := NewExporterStats(key)
+	r.exporters[key] = stats
+
+	if r.metrics != nil {
+		r.metrics.ActiveExporters.Set(float64(len(r.exporters)))
+	}
+
+	if log != nil {
+		log.WithField("exporter", key.IP).WithField("source_id", key.SourceID).Info("New exporter registered")
+	}
+
+	return stats
+}
+
+// RecordPacket records a packet from an exporter
+func (r *ExporterRegistry) RecordPacket(ip net.IP, sourceID uint32, bytes int) {
+	stats := r.GetOrCreate(ip, sourceID)
+	stats.RecordPacket(bytes)
+
+	if r.metrics != nil {
+		labels := prometheus.Labels{
+			"exporter_ip": ip.String(),
+			"source_id":   string(rune(sourceID)),
+		}
+		r.metrics.PacketsReceived.With(labels).Inc()
+		r.metrics.BytesReceived.With(labels).Add(float64(bytes))
+		r.metrics.LastSeen.With(labels).SetToCurrentTime()
+	}
+}
+
+// RecordFlows records flows from an exporter
+func (r *ExporterRegistry) RecordFlows(ip net.IP, sourceID uint32, count int) {
+	stats := r.GetOrCreate(ip, sourceID)
+	stats.RecordFlows(count)
+
+	if r.metrics != nil {
+		labels := prometheus.Labels{
+			"exporter_ip": ip.String(),
+			"source_id":   string(rune(sourceID)),
+		}
+		r.metrics.FlowsProcessed.With(labels).Add(float64(count))
+	}
+}
+
+// RecordError records an error from an exporter
+func (r *ExporterRegistry) RecordError(ip net.IP, sourceID uint32) {
+	stats := r.GetOrCreate(ip, sourceID)
+	stats.RecordError()
+
+	if r.metrics != nil {
+		labels := prometheus.Labels{
+			"exporter_ip": ip.String(),
+			"source_id":   string(rune(sourceID)),
+		}
+		r.metrics.Errors.With(labels).Inc()
+	}
+}
+
+// ExporterStatsSnapshot is a point-in-time snapshot of exporter statistics
+type ExporterStatsSnapshot struct {
+	Key             ExporterKey
+	PacketsReceived uint64
+	BytesReceived   uint64
+	FlowsProcessed  uint64
+	Errors          uint64
+	LastSeen        time.Time
+}
+
+// GetAllExporters returns a snapshot of all exporter statistics
+func (r *ExporterRegistry) GetAllExporters() map[ExporterKey]ExporterStatsSnapshot {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make(map[ExporterKey]ExporterStatsSnapshot, len(r.exporters))
+	for k, v := range r.exporters {
+		packets, bytes, flows, errors, lastSeen := v.GetStats()
+		result[k] = ExporterStatsSnapshot{
+			Key:             k,
+			PacketsReceived: packets,
+			BytesReceived:   bytes,
+			FlowsProcessed:  flows,
+			Errors:          errors,
+			LastSeen:        lastSeen,
+		}
+	}
+	return result
+}

--- a/collector/pool.go
+++ b/collector/pool.go
@@ -1,0 +1,369 @@
+package collector
+
+import (
+	"context"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sirupsen/logrus"
+)
+
+var log *logrus.Logger
+
+func SetLogger(l *logrus.Logger) {
+	log = l
+}
+
+// PacketWork represents a unit of work for packet processing
+type PacketWork struct {
+	Data       []byte
+	Length     int
+	RemoteAddr net.Addr
+	ReceivedAt time.Time
+}
+
+// RingBuffer is a fixed-size circular buffer for packet work items
+type RingBuffer struct {
+	items    []PacketWork
+	size     uint64
+	head     uint64 // Write position (producer)
+	tail     uint64 // Read position (consumer)
+	mask     uint64
+	mu       sync.Mutex
+	notEmpty *sync.Cond
+	notFull  *sync.Cond
+	closed   atomic.Bool
+}
+
+// NewRingBuffer creates a new ring buffer with the given size (must be power of 2)
+func NewRingBuffer(size int) *RingBuffer {
+	// Round up to nearest power of 2
+	actualSize := uint64(1)
+	for actualSize < uint64(size) {
+		actualSize <<= 1
+	}
+
+	rb := &RingBuffer{
+		items: make([]PacketWork, actualSize),
+		size:  actualSize,
+		mask:  actualSize - 1,
+	}
+	rb.notEmpty = sync.NewCond(&rb.mu)
+	rb.notFull = sync.NewCond(&rb.mu)
+	return rb
+}
+
+// Push adds an item to the buffer. Returns false if buffer is full (non-blocking)
+func (rb *RingBuffer) Push(work PacketWork) bool {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	if rb.closed.Load() {
+		return false
+	}
+
+	// Check if full
+	if rb.head-rb.tail >= rb.size {
+		return false
+	}
+
+	rb.items[rb.head&rb.mask] = work
+	rb.head++
+	rb.notEmpty.Signal()
+	return true
+}
+
+// PushBlocking adds an item to the buffer, blocking if full
+func (rb *RingBuffer) PushBlocking(ctx context.Context, work PacketWork) bool {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	for rb.head-rb.tail >= rb.size && !rb.closed.Load() {
+		// Check context before waiting
+		select {
+		case <-ctx.Done():
+			return false
+		default:
+		}
+		rb.notFull.Wait()
+	}
+
+	if rb.closed.Load() {
+		return false
+	}
+
+	rb.items[rb.head&rb.mask] = work
+	rb.head++
+	rb.notEmpty.Signal()
+	return true
+}
+
+// Pop removes and returns an item from the buffer. Blocks if empty
+func (rb *RingBuffer) Pop(ctx context.Context) (PacketWork, bool) {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	for rb.head == rb.tail && !rb.closed.Load() {
+		select {
+		case <-ctx.Done():
+			return PacketWork{}, false
+		default:
+		}
+		rb.notEmpty.Wait()
+	}
+
+	if rb.closed.Load() && rb.head == rb.tail {
+		return PacketWork{}, false
+	}
+
+	work := rb.items[rb.tail&rb.mask]
+	// Clear the reference to help GC
+	rb.items[rb.tail&rb.mask] = PacketWork{}
+	rb.tail++
+	rb.notFull.Signal()
+	return work, true
+}
+
+// Len returns the current number of items in the buffer
+func (rb *RingBuffer) Len() int {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	return int(rb.head - rb.tail)
+}
+
+// Close closes the ring buffer
+func (rb *RingBuffer) Close() {
+	rb.closed.Store(true)
+	rb.mu.Lock()
+	rb.notEmpty.Broadcast()
+	rb.notFull.Broadcast()
+	rb.mu.Unlock()
+}
+
+// WorkerPool manages a fixed pool of workers that process packets
+type WorkerPool struct {
+	numWorkers   int
+	ringBuffer   *RingBuffer
+	bytePool     *ByteBufferPool
+	workPool     *WorkItemPool
+	handler      PacketHandler
+	wg           sync.WaitGroup
+	ctx          context.Context
+	cancel       context.CancelFunc
+	metrics      *PoolMetrics
+	dropCallback func(PacketWork)
+}
+
+// PacketHandler is the function signature for packet processing
+type PacketHandler func(ctx context.Context, work *PacketWork) error
+
+// PoolMetrics holds prometheus metrics for the worker pool
+type PoolMetrics struct {
+	PacketsReceived   prometheus.Counter
+	PacketsProcessed  prometheus.Counter
+	PacketsDropped    prometheus.Counter
+	QueueDepth        prometheus.Gauge
+	ProcessingLatency prometheus.Histogram
+	WorkersBusy       prometheus.Gauge
+}
+
+func NewPoolMetrics(namespace string) *PoolMetrics {
+	return &PoolMetrics{
+		PacketsReceived: promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "packets_received_total",
+			Help:      "Total number of packets received",
+		}),
+		PacketsProcessed: promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "packets_processed_total",
+			Help:      "Total number of packets successfully processed",
+		}),
+		PacketsDropped: promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "packets_dropped_total",
+			Help:      "Total number of packets dropped due to queue overflow",
+		}),
+		QueueDepth: promauto.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "queue_depth",
+			Help:      "Current number of packets waiting in queue",
+		}),
+		ProcessingLatency: promauto.NewHistogram(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "processing_latency_seconds",
+			Help:      "Time from packet receipt to processing completion",
+			Buckets:   []float64{.0001, .0005, .001, .005, .01, .05, .1, .5, 1},
+		}),
+		WorkersBusy: promauto.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "workers_busy",
+			Help:      "Number of workers currently processing packets",
+		}),
+	}
+}
+
+// WorkerPoolConfig holds configuration for the worker pool
+type WorkerPoolConfig struct {
+	NumWorkers      int
+	QueueSize       int
+	MaxPacketSize   int
+	Handler         PacketHandler
+	Metrics         *PoolMetrics
+	DropCallback    func(PacketWork)
+	Blocking        bool // If true, block on full queue instead of dropping
+}
+
+// NewWorkerPool creates a new worker pool
+func NewWorkerPool(cfg *WorkerPoolConfig) *WorkerPool {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if cfg.MaxPacketSize == 0 {
+		cfg.MaxPacketSize = 65535 // Max UDP packet size
+	}
+
+	pool := &WorkerPool{
+		numWorkers:   cfg.NumWorkers,
+		ringBuffer:   NewRingBuffer(cfg.QueueSize),
+		bytePool:     NewByteBufferPool(cfg.MaxPacketSize),
+		workPool:     NewWorkItemPool(),
+		handler:      cfg.Handler,
+		ctx:          ctx,
+		cancel:       cancel,
+		metrics:      cfg.Metrics,
+		dropCallback: cfg.DropCallback,
+	}
+
+	return pool
+}
+
+// Start launches the worker goroutines
+func (wp *WorkerPool) Start() {
+	for i := 0; i < wp.numWorkers; i++ {
+		wp.wg.Add(1)
+		go wp.worker(i)
+	}
+
+	// Start metrics updater
+	go wp.metricsUpdater()
+}
+
+func (wp *WorkerPool) worker(id int) {
+	defer wp.wg.Done()
+
+	_ = id // Worker ID can be used for debugging/metrics
+
+	for {
+		work, ok := wp.ringBuffer.Pop(wp.ctx)
+		if !ok {
+			return
+		}
+
+		if wp.metrics != nil {
+			wp.metrics.WorkersBusy.Inc()
+		}
+
+		if err := wp.handler(wp.ctx, &work); err != nil {
+			if log != nil {
+				log.WithError(err).Debug("Error processing packet")
+			}
+		}
+
+		if wp.metrics != nil {
+			wp.metrics.PacketsProcessed.Inc()
+			wp.metrics.ProcessingLatency.Observe(time.Since(work.ReceivedAt).Seconds())
+			wp.metrics.WorkersBusy.Dec()
+		}
+
+		// Return the byte buffer to the pool
+		wp.bytePool.Put(work.Data)
+	}
+}
+
+func (wp *WorkerPool) metricsUpdater() {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-wp.ctx.Done():
+			return
+		case <-ticker.C:
+			if wp.metrics != nil {
+				wp.metrics.QueueDepth.Set(float64(wp.ringBuffer.Len()))
+			}
+		}
+	}
+}
+
+// Submit submits work to the pool. Returns false if the work was dropped
+func (wp *WorkerPool) Submit(data []byte, length int, remoteAddr net.Addr) bool {
+	if wp.metrics != nil {
+		wp.metrics.PacketsReceived.Inc()
+	}
+
+	// Get a buffer from the pool and copy data
+	buf := wp.bytePool.Get()
+	copy(buf[:length], data[:length])
+
+	work := PacketWork{
+		Data:       buf[:length],
+		Length:     length,
+		RemoteAddr: remoteAddr,
+		ReceivedAt: time.Now(),
+	}
+
+	if !wp.ringBuffer.Push(work) {
+		// Queue is full, drop the packet
+		if wp.metrics != nil {
+			wp.metrics.PacketsDropped.Inc()
+		}
+		if wp.dropCallback != nil {
+			wp.dropCallback(work)
+		}
+		wp.bytePool.Put(buf)
+		return false
+	}
+
+	return true
+}
+
+// SubmitBlocking submits work and blocks if the queue is full
+func (wp *WorkerPool) SubmitBlocking(ctx context.Context, data []byte, length int, remoteAddr net.Addr) bool {
+	if wp.metrics != nil {
+		wp.metrics.PacketsReceived.Inc()
+	}
+
+	buf := wp.bytePool.Get()
+	copy(buf[:length], data[:length])
+
+	work := PacketWork{
+		Data:       buf[:length],
+		Length:     length,
+		RemoteAddr: remoteAddr,
+		ReceivedAt: time.Now(),
+	}
+
+	if !wp.ringBuffer.PushBlocking(ctx, work) {
+		wp.bytePool.Put(buf)
+		return false
+	}
+
+	return true
+}
+
+// Stop gracefully shuts down the worker pool
+func (wp *WorkerPool) Stop() {
+	wp.cancel()
+	wp.ringBuffer.Close()
+	wp.wg.Wait()
+}
+
+// QueueLen returns the current queue depth
+func (wp *WorkerPool) QueueLen() int {
+	return wp.ringBuffer.Len()
+}

--- a/collector/pool_test.go
+++ b/collector/pool_test.go
@@ -1,0 +1,241 @@
+package collector
+
+import (
+	"context"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRingBuffer_PushPop(t *testing.T) {
+	rb := NewRingBuffer(8)
+
+	// Push some items
+	for i := 0; i < 5; i++ {
+		work := PacketWork{
+			Data:   []byte{byte(i)},
+			Length: 1,
+		}
+		if !rb.Push(work) {
+			t.Errorf("Push failed at index %d", i)
+		}
+	}
+
+	if rb.Len() != 5 {
+		t.Errorf("Expected length 5, got %d", rb.Len())
+	}
+
+	// Pop items
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		work, ok := rb.Pop(ctx)
+		if !ok {
+			t.Errorf("Pop failed at index %d", i)
+		}
+		if work.Data[0] != byte(i) {
+			t.Errorf("Expected data %d, got %d", i, work.Data[0])
+		}
+	}
+
+	if rb.Len() != 0 {
+		t.Errorf("Expected length 0, got %d", rb.Len())
+	}
+}
+
+func TestRingBuffer_Full(t *testing.T) {
+	rb := NewRingBuffer(4) // Will round to power of 2
+
+	// Fill the buffer
+	for i := 0; i < 4; i++ {
+		work := PacketWork{Data: []byte{byte(i)}, Length: 1}
+		if !rb.Push(work) {
+			t.Errorf("Push should succeed at index %d", i)
+		}
+	}
+
+	// Buffer should be full
+	work := PacketWork{Data: []byte{99}, Length: 1}
+	if rb.Push(work) {
+		t.Error("Push should fail when buffer is full")
+	}
+}
+
+func TestRingBuffer_Close(t *testing.T) {
+	rb := NewRingBuffer(8)
+
+	// Push an item
+	rb.Push(PacketWork{Data: []byte{1}, Length: 1})
+
+	// Close the buffer
+	rb.Close()
+
+	// Pop should still return the existing item
+	ctx := context.Background()
+	_, ok := rb.Pop(ctx)
+	if !ok {
+		t.Error("Should be able to pop existing items after close")
+	}
+
+	// Push should fail after close
+	if rb.Push(PacketWork{Data: []byte{2}, Length: 1}) {
+		t.Error("Push should fail after close")
+	}
+}
+
+func TestRingBuffer_Concurrent(t *testing.T) {
+	rb := NewRingBuffer(1024)
+	ctx := context.Background()
+
+	var pushed, popped atomic.Int64
+	var wg sync.WaitGroup
+
+	// Start producers
+	numProducers := 4
+	numItems := 1000
+	for i := 0; i < numProducers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < numItems; j++ {
+				work := PacketWork{Data: []byte{1}, Length: 1}
+				if rb.PushBlocking(ctx, work) {
+					pushed.Add(1)
+				}
+			}
+		}()
+	}
+
+	// Start consumers
+	numConsumers := 4
+	done := make(chan bool)
+	for i := 0; i < numConsumers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					// Drain remaining items
+					for {
+						_, ok := rb.Pop(ctx)
+						if !ok {
+							return
+						}
+						popped.Add(1)
+					}
+				default:
+					_, ok := rb.Pop(ctx)
+					if ok {
+						popped.Add(1)
+					}
+				}
+			}
+		}()
+	}
+
+	// Wait for producers
+	time.Sleep(time.Second)
+	close(done)
+	rb.Close()
+	wg.Wait()
+
+	t.Logf("Pushed: %d, Popped: %d", pushed.Load(), popped.Load())
+}
+
+func TestByteBufferPool(t *testing.T) {
+	pool := NewByteBufferPool(1024)
+
+	// Get buffers
+	buf1 := pool.Get()
+	buf2 := pool.Get()
+
+	if len(buf1) != 1024 {
+		t.Errorf("Expected buffer length 1024, got %d", len(buf1))
+	}
+
+	// Modify and return
+	buf1[0] = 42
+	pool.Put(buf1)
+
+	// Get again - should be cleared
+	buf3 := pool.Get()
+	if buf3[0] != 0 {
+		t.Error("Buffer was not cleared before returning to pool")
+	}
+
+	pool.Put(buf2)
+	pool.Put(buf3)
+}
+
+func TestWorkerPool_Submit(t *testing.T) {
+	var processed atomic.Int64
+
+	handler := func(ctx context.Context, work *PacketWork) error {
+		processed.Add(1)
+		return nil
+	}
+
+	pool := NewWorkerPool(&WorkerPoolConfig{
+		NumWorkers:    2,
+		QueueSize:     100,
+		MaxPacketSize: 1024,
+		Handler:       handler,
+	})
+
+	pool.Start()
+
+	// Submit work
+	for i := 0; i < 50; i++ {
+		data := []byte{byte(i)}
+		addr := &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 1234}
+		pool.Submit(data, 1, addr)
+	}
+
+	// Wait for processing
+	time.Sleep(100 * time.Millisecond)
+
+	pool.Stop()
+
+	if processed.Load() != 50 {
+		t.Errorf("Expected 50 processed, got %d", processed.Load())
+	}
+}
+
+func TestWorkerPool_Drop(t *testing.T) {
+	var dropped atomic.Int64
+
+	handler := func(ctx context.Context, work *PacketWork) error {
+		time.Sleep(10 * time.Millisecond) // Slow handler
+		return nil
+	}
+
+	pool := NewWorkerPool(&WorkerPoolConfig{
+		NumWorkers:    1,
+		QueueSize:     4, // Small queue
+		MaxPacketSize: 64,
+		Handler:       handler,
+		DropCallback: func(w PacketWork) {
+			dropped.Add(1)
+		},
+	})
+
+	pool.Start()
+
+	// Submit more work than queue can hold
+	for i := 0; i < 20; i++ {
+		data := []byte{byte(i)}
+		addr := &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 1234}
+		pool.Submit(data, 1, addr)
+	}
+
+	// Some should have been dropped
+	time.Sleep(50 * time.Millisecond)
+	pool.Stop()
+
+	if dropped.Load() == 0 {
+		t.Error("Expected some packets to be dropped")
+	}
+	t.Logf("Dropped: %d", dropped.Load())
+}

--- a/dedup/cache.go
+++ b/dedup/cache.go
@@ -1,0 +1,516 @@
+package dedup
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sirupsen/logrus"
+)
+
+var log *logrus.Logger
+
+func SetLogger(l *logrus.Logger) {
+	log = l
+}
+
+// FlowKey represents the unique identifier for a flow (5-tuple + exporter)
+type FlowKey struct {
+	SrcIP    [16]byte // IPv6 capable
+	DstIP    [16]byte
+	SrcPort  uint16
+	DstPort  uint16
+	Protocol uint8
+	// Include exporter info to handle same flow from multiple exporters
+	ExporterIP [16]byte
+	SourceID   uint32
+}
+
+// Hash returns a hash of the flow key
+func (k *FlowKey) Hash() uint64 {
+	h := fnv.New64a()
+	h.Write(k.SrcIP[:])
+	h.Write(k.DstIP[:])
+	binary.Write(h, binary.BigEndian, k.SrcPort)
+	binary.Write(h, binary.BigEndian, k.DstPort)
+	h.Write([]byte{k.Protocol})
+	h.Write(k.ExporterIP[:])
+	binary.Write(h, binary.BigEndian, k.SourceID)
+	return h.Sum64()
+}
+
+// FlowEntry represents a cached flow entry
+type FlowEntry struct {
+	Key          FlowKey
+	FirstSeen    time.Time
+	LastSeen     time.Time
+	Bytes        uint64
+	Packets      uint64
+	FlowSeq      uint64 // Sequence number for ordering
+	hash         uint64
+	prev, next   *FlowEntry // LRU list pointers
+}
+
+// DedupCache implements a per-exporter deduplication cache with TTL and size bounds
+type DedupCache struct {
+	// Configuration
+	maxSize  int
+	ttl      time.Duration
+
+	// Per-exporter caches using sharding to reduce lock contention
+	shards     []*cacheShard
+	numShards  int
+
+	// Metrics
+	metrics *DedupMetrics
+
+	// Background cleanup
+	cleanupTicker *time.Ticker
+	stopCh        chan struct{}
+	wg            sync.WaitGroup
+}
+
+// cacheShard is a single shard of the cache
+type cacheShard struct {
+	entries map[uint64]*FlowEntry
+	// LRU list
+	head, tail *FlowEntry
+	size       int
+	maxSize    int
+	mu         sync.Mutex
+}
+
+// DedupMetrics holds prometheus metrics for deduplication
+type DedupMetrics struct {
+	CacheHits        prometheus.Counter
+	CacheMisses      prometheus.Counter
+	DuplicatesFound  prometheus.Counter
+	Evictions        prometheus.Counter
+	ExpiredEvictions prometheus.Counter
+	CacheSize        prometheus.Gauge
+	CacheCapacity    prometheus.Gauge
+}
+
+// NewDedupMetrics creates prometheus metrics for deduplication
+func NewDedupMetrics(namespace string) *DedupMetrics {
+	return &DedupMetrics{
+		CacheHits: promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "dedup",
+			Name:      "cache_hits_total",
+			Help:      "Total number of cache hits (duplicate flows)",
+		}),
+		CacheMisses: promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "dedup",
+			Name:      "cache_misses_total",
+			Help:      "Total number of cache misses (new flows)",
+		}),
+		DuplicatesFound: promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "dedup",
+			Name:      "duplicates_total",
+			Help:      "Total number of duplicate flows suppressed",
+		}),
+		Evictions: promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "dedup",
+			Name:      "evictions_total",
+			Help:      "Total number of cache evictions due to size limit",
+		}),
+		ExpiredEvictions: promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "dedup",
+			Name:      "expired_evictions_total",
+			Help:      "Total number of cache evictions due to TTL expiry",
+		}),
+		CacheSize: promauto.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "dedup",
+			Name:      "cache_size",
+			Help:      "Current number of entries in the cache",
+		}),
+		CacheCapacity: promauto.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "dedup",
+			Name:      "cache_capacity",
+			Help:      "Maximum capacity of the cache",
+		}),
+	}
+}
+
+// DedupCacheConfig holds configuration for the dedup cache
+type DedupCacheConfig struct {
+	MaxSize         int            // Maximum total entries across all shards
+	TTL             time.Duration  // Time-to-live for entries
+	NumShards       int            // Number of shards (default: 16)
+	CleanupInterval time.Duration  // How often to run cleanup (default: TTL/4)
+	Metrics         *DedupMetrics
+}
+
+// NewDedupCache creates a new deduplication cache
+func NewDedupCache(cfg *DedupCacheConfig) *DedupCache {
+	if cfg.NumShards <= 0 {
+		cfg.NumShards = 16
+	}
+	if cfg.CleanupInterval == 0 {
+		cfg.CleanupInterval = cfg.TTL / 4
+		if cfg.CleanupInterval < time.Second {
+			cfg.CleanupInterval = time.Second
+		}
+	}
+
+	maxPerShard := cfg.MaxSize / cfg.NumShards
+	if maxPerShard < 1 {
+		maxPerShard = 1
+	}
+
+	shards := make([]*cacheShard, cfg.NumShards)
+	for i := range shards {
+		shards[i] = &cacheShard{
+			entries: make(map[uint64]*FlowEntry),
+			maxSize: maxPerShard,
+		}
+	}
+
+	c := &DedupCache{
+		maxSize:   cfg.MaxSize,
+		ttl:       cfg.TTL,
+		shards:    shards,
+		numShards: cfg.NumShards,
+		metrics:   cfg.Metrics,
+		stopCh:    make(chan struct{}),
+	}
+
+	if cfg.Metrics != nil {
+		cfg.Metrics.CacheCapacity.Set(float64(cfg.MaxSize))
+	}
+
+	// Start background cleanup
+	c.cleanupTicker = time.NewTicker(cfg.CleanupInterval)
+	c.wg.Add(1)
+	go c.cleanupLoop()
+
+	return c
+}
+
+func (c *DedupCache) getShard(hash uint64) *cacheShard {
+	return c.shards[hash%uint64(c.numShards)]
+}
+
+// CheckDuplicate checks if a flow is a duplicate. Returns true if this is a duplicate
+// that should be suppressed. Updates the cache entry if not suppressed.
+//
+// Deduplication heuristics:
+// - A flow is considered duplicate if we've seen it within the TTL window
+// - Long-lived flows: We update the entry but don't suppress if the flow
+//   has been active for more than TTL (allows periodic updates through)
+// - We track bytes/packets to detect flow continuations vs true duplicates
+func (c *DedupCache) CheckDuplicate(key *FlowKey, bytes, packets uint64, flowSeq uint64) (isDuplicate bool) {
+	hash := key.Hash()
+	shard := c.getShard(hash)
+
+	shard.mu.Lock()
+	defer shard.mu.Unlock()
+
+	now := time.Now()
+	entry, exists := shard.entries[hash]
+
+	if exists {
+		// Check if entry has expired
+		if now.Sub(entry.LastSeen) > c.ttl {
+			// Entry expired, treat as new flow
+			entry.FirstSeen = now
+			entry.LastSeen = now
+			entry.Bytes = bytes
+			entry.Packets = packets
+			entry.FlowSeq = flowSeq
+			shard.moveToFront(entry)
+
+			if c.metrics != nil {
+				c.metrics.CacheMisses.Inc()
+			}
+			return false
+		}
+
+		// Entry exists and is still valid - check for duplicate
+		//
+		// Heuristic: If bytes/packets haven't changed and we're within TTL,
+		// this is likely a duplicate. However, for long-lived flows that
+		// send periodic updates, we want to allow through if:
+		// 1. The flow sequence has advanced
+		// 2. The byte/packet counts have increased
+		// 3. The flow has been active longer than TTL (periodic refresh)
+
+		isDuplicate = true
+
+		// Allow through if flow data has increased (continuation, not duplicate)
+		if bytes > entry.Bytes || packets > entry.Packets {
+			isDuplicate = false
+		}
+
+		// Allow through if sequence number advanced (prevents suppressing updates)
+		if flowSeq > entry.FlowSeq && flowSeq != 0 {
+			isDuplicate = false
+		}
+
+		// For long-lived flows (active > TTL), allow periodic updates through
+		// This prevents legitimate flow updates from being suppressed
+		flowAge := now.Sub(entry.FirstSeen)
+		if flowAge > c.ttl && now.Sub(entry.LastSeen) > c.ttl/2 {
+			isDuplicate = false
+		}
+
+		// Update entry regardless
+		entry.LastSeen = now
+		if bytes > entry.Bytes {
+			entry.Bytes = bytes
+		}
+		if packets > entry.Packets {
+			entry.Packets = packets
+		}
+		if flowSeq > entry.FlowSeq {
+			entry.FlowSeq = flowSeq
+		}
+		shard.moveToFront(entry)
+
+		if c.metrics != nil {
+			c.metrics.CacheHits.Inc()
+			if isDuplicate {
+				c.metrics.DuplicatesFound.Inc()
+			}
+		}
+
+		return isDuplicate
+	}
+
+	// New flow - add to cache
+	entry = &FlowEntry{
+		Key:       *key,
+		FirstSeen: now,
+		LastSeen:  now,
+		Bytes:     bytes,
+		Packets:   packets,
+		FlowSeq:   flowSeq,
+		hash:      hash,
+	}
+
+	// Evict if at capacity
+	if shard.size >= shard.maxSize {
+		shard.evictOldest()
+		if c.metrics != nil {
+			c.metrics.Evictions.Inc()
+		}
+	}
+
+	shard.entries[hash] = entry
+	shard.addToFront(entry)
+	shard.size++
+
+	if c.metrics != nil {
+		c.metrics.CacheMisses.Inc()
+		c.metrics.CacheSize.Inc()
+	}
+
+	return false
+}
+
+// moveToFront moves an entry to the front of the LRU list
+func (s *cacheShard) moveToFront(entry *FlowEntry) {
+	if s.head == entry {
+		return
+	}
+
+	// Remove from current position
+	if entry.prev != nil {
+		entry.prev.next = entry.next
+	}
+	if entry.next != nil {
+		entry.next.prev = entry.prev
+	}
+	if s.tail == entry {
+		s.tail = entry.prev
+	}
+
+	// Add to front
+	entry.prev = nil
+	entry.next = s.head
+	if s.head != nil {
+		s.head.prev = entry
+	}
+	s.head = entry
+	if s.tail == nil {
+		s.tail = entry
+	}
+}
+
+// addToFront adds a new entry to the front of the LRU list
+func (s *cacheShard) addToFront(entry *FlowEntry) {
+	entry.prev = nil
+	entry.next = s.head
+	if s.head != nil {
+		s.head.prev = entry
+	}
+	s.head = entry
+	if s.tail == nil {
+		s.tail = entry
+	}
+}
+
+// evictOldest removes the oldest entry from the cache
+func (s *cacheShard) evictOldest() {
+	if s.tail == nil {
+		return
+	}
+
+	entry := s.tail
+
+	// Remove from list
+	if entry.prev != nil {
+		entry.prev.next = nil
+	}
+	s.tail = entry.prev
+	if s.head == entry {
+		s.head = nil
+	}
+
+	// Remove from map
+	delete(s.entries, entry.hash)
+	s.size--
+}
+
+// cleanupLoop runs periodic cleanup of expired entries
+func (c *DedupCache) cleanupLoop() {
+	defer c.wg.Done()
+
+	for {
+		select {
+		case <-c.cleanupTicker.C:
+			c.cleanupExpired()
+		case <-c.stopCh:
+			return
+		}
+	}
+}
+
+// cleanupExpired removes expired entries from the cache
+func (c *DedupCache) cleanupExpired() {
+	now := time.Now()
+	var totalSize atomic.Int64
+
+	for _, shard := range c.shards {
+		shard.mu.Lock()
+
+		// Walk from tail (oldest) and remove expired
+		entry := shard.tail
+		for entry != nil {
+			if now.Sub(entry.LastSeen) > c.ttl {
+				prev := entry.prev
+
+				// Remove from list
+				if entry.prev != nil {
+					entry.prev.next = entry.next
+				}
+				if entry.next != nil {
+					entry.next.prev = entry.prev
+				}
+				if shard.head == entry {
+					shard.head = entry.next
+				}
+				if shard.tail == entry {
+					shard.tail = entry.prev
+				}
+
+				// Remove from map
+				delete(shard.entries, entry.hash)
+				shard.size--
+
+				if c.metrics != nil {
+					c.metrics.ExpiredEvictions.Inc()
+				}
+
+				entry = prev
+			} else {
+				// Since list is ordered by access time, no more expired entries
+				break
+			}
+		}
+
+		totalSize.Add(int64(shard.size))
+		shard.mu.Unlock()
+	}
+
+	if c.metrics != nil {
+		c.metrics.CacheSize.Set(float64(totalSize.Load()))
+	}
+}
+
+// Size returns the current total size of the cache
+func (c *DedupCache) Size() int {
+	var total int
+	for _, shard := range c.shards {
+		shard.mu.Lock()
+		total += shard.size
+		shard.mu.Unlock()
+	}
+	return total
+}
+
+// Clear removes all entries from the cache
+func (c *DedupCache) Clear() {
+	for _, shard := range c.shards {
+		shard.mu.Lock()
+		shard.entries = make(map[uint64]*FlowEntry)
+		shard.head = nil
+		shard.tail = nil
+		shard.size = 0
+		shard.mu.Unlock()
+	}
+
+	if c.metrics != nil {
+		c.metrics.CacheSize.Set(0)
+	}
+}
+
+// Stop stops the background cleanup routine
+func (c *DedupCache) Stop() {
+	close(c.stopCh)
+	c.cleanupTicker.Stop()
+	c.wg.Wait()
+}
+
+// MakeFlowKey creates a FlowKey from flow parameters
+func MakeFlowKey(srcIP, dstIP net.IP, srcPort, dstPort uint16, protocol uint8, exporterIP net.IP, sourceID uint32) FlowKey {
+	key := FlowKey{
+		SrcPort:  srcPort,
+		DstPort:  dstPort,
+		Protocol: protocol,
+		SourceID: sourceID,
+	}
+
+	// Handle IPv4 and IPv6
+	if srcIP4 := srcIP.To4(); srcIP4 != nil {
+		copy(key.SrcIP[12:], srcIP4)
+	} else {
+		copy(key.SrcIP[:], srcIP.To16())
+	}
+
+	if dstIP4 := dstIP.To4(); dstIP4 != nil {
+		copy(key.DstIP[12:], dstIP4)
+	} else {
+		copy(key.DstIP[:], dstIP.To16())
+	}
+
+	if expIP4 := exporterIP.To4(); expIP4 != nil {
+		copy(key.ExporterIP[12:], expIP4)
+	} else if exporterIP != nil {
+		copy(key.ExporterIP[:], exporterIP.To16())
+	}
+
+	return key
+}

--- a/dedup/cache_test.go
+++ b/dedup/cache_test.go
@@ -1,0 +1,315 @@
+package dedup
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestDedupCache_BasicDuplication(t *testing.T) {
+	cache := NewDedupCache(&DedupCacheConfig{
+		MaxSize: 1000,
+		TTL:     time.Minute,
+	})
+	defer cache.Stop()
+
+	key := MakeFlowKey(
+		net.ParseIP("192.168.1.1"),
+		net.ParseIP("192.168.1.2"),
+		12345, 80, 6,
+		net.ParseIP("10.0.0.1"),
+		100,
+	)
+
+	// First occurrence - should NOT be duplicate
+	isDup := cache.CheckDuplicate(&key, 1000, 10, 1)
+	if isDup {
+		t.Error("First occurrence should not be duplicate")
+	}
+
+	// Immediate second occurrence with same values - should be duplicate
+	isDup = cache.CheckDuplicate(&key, 1000, 10, 1)
+	if !isDup {
+		t.Error("Immediate repeat should be duplicate")
+	}
+}
+
+func TestDedupCache_UpdatedFlow(t *testing.T) {
+	cache := NewDedupCache(&DedupCacheConfig{
+		MaxSize: 1000,
+		TTL:     time.Minute,
+	})
+	defer cache.Stop()
+
+	key := MakeFlowKey(
+		net.ParseIP("192.168.1.1"),
+		net.ParseIP("192.168.1.2"),
+		12345, 80, 6,
+		net.ParseIP("10.0.0.1"),
+		100,
+	)
+
+	// First occurrence
+	cache.CheckDuplicate(&key, 1000, 10, 1)
+
+	// Updated flow with more bytes - should NOT be duplicate
+	isDup := cache.CheckDuplicate(&key, 2000, 20, 2)
+	if isDup {
+		t.Error("Flow with increased bytes should not be duplicate")
+	}
+}
+
+func TestDedupCache_SequenceAdvance(t *testing.T) {
+	cache := NewDedupCache(&DedupCacheConfig{
+		MaxSize: 1000,
+		TTL:     time.Minute,
+	})
+	defer cache.Stop()
+
+	key := MakeFlowKey(
+		net.ParseIP("192.168.1.1"),
+		net.ParseIP("192.168.1.2"),
+		12345, 80, 6,
+		net.ParseIP("10.0.0.1"),
+		100,
+	)
+
+	// First occurrence
+	cache.CheckDuplicate(&key, 1000, 10, 1)
+
+	// Same bytes/packets but sequence advanced - should NOT be duplicate
+	isDup := cache.CheckDuplicate(&key, 1000, 10, 2)
+	if isDup {
+		t.Error("Flow with advanced sequence should not be duplicate")
+	}
+}
+
+func TestDedupCache_DifferentFlows(t *testing.T) {
+	cache := NewDedupCache(&DedupCacheConfig{
+		MaxSize: 1000,
+		TTL:     time.Minute,
+	})
+	defer cache.Stop()
+
+	key1 := MakeFlowKey(
+		net.ParseIP("192.168.1.1"),
+		net.ParseIP("192.168.1.2"),
+		12345, 80, 6,
+		net.ParseIP("10.0.0.1"),
+		100,
+	)
+
+	key2 := MakeFlowKey(
+		net.ParseIP("192.168.1.1"),
+		net.ParseIP("192.168.1.3"), // Different dst
+		12345, 80, 6,
+		net.ParseIP("10.0.0.1"),
+		100,
+	)
+
+	// Both should not be duplicates
+	isDup1 := cache.CheckDuplicate(&key1, 1000, 10, 1)
+	isDup2 := cache.CheckDuplicate(&key2, 1000, 10, 1)
+
+	if isDup1 || isDup2 {
+		t.Error("Different flows should not be duplicates")
+	}
+}
+
+func TestDedupCache_TTLExpiry(t *testing.T) {
+	cache := NewDedupCache(&DedupCacheConfig{
+		MaxSize:         1000,
+		TTL:             50 * time.Millisecond,
+		CleanupInterval: 10 * time.Millisecond,
+	})
+	defer cache.Stop()
+
+	key := MakeFlowKey(
+		net.ParseIP("192.168.1.1"),
+		net.ParseIP("192.168.1.2"),
+		12345, 80, 6,
+		net.ParseIP("10.0.0.1"),
+		100,
+	)
+
+	// First occurrence
+	cache.CheckDuplicate(&key, 1000, 10, 1)
+
+	// Wait for TTL to expire
+	time.Sleep(100 * time.Millisecond)
+
+	// Should not be duplicate after TTL
+	isDup := cache.CheckDuplicate(&key, 1000, 10, 1)
+	if isDup {
+		t.Error("Flow after TTL expiry should not be duplicate")
+	}
+}
+
+func TestDedupCache_Eviction(t *testing.T) {
+	cache := NewDedupCache(&DedupCacheConfig{
+		MaxSize:   8,
+		TTL:       time.Minute,
+		NumShards: 2, // 4 per shard
+	})
+	defer cache.Stop()
+
+	// Fill cache with more than capacity
+	for i := 0; i < 20; i++ {
+		key := MakeFlowKey(
+			net.ParseIP("192.168.1.1"),
+			net.IP{192, 168, 1, byte(i)},
+			uint16(i), 80, 6,
+			net.ParseIP("10.0.0.1"),
+			100,
+		)
+		cache.CheckDuplicate(&key, 1000, 10, 1)
+	}
+
+	// Size should be bounded
+	size := cache.Size()
+	if size > 16 { // Some slack due to sharding
+		t.Errorf("Cache size %d exceeds expected max", size)
+	}
+}
+
+func TestDedupCache_Clear(t *testing.T) {
+	cache := NewDedupCache(&DedupCacheConfig{
+		MaxSize: 1000,
+		TTL:     time.Minute,
+	})
+	defer cache.Stop()
+
+	// Add some entries
+	for i := 0; i < 10; i++ {
+		key := MakeFlowKey(
+			net.ParseIP("192.168.1.1"),
+			net.IP{192, 168, 1, byte(i)},
+			uint16(i), 80, 6,
+			net.ParseIP("10.0.0.1"),
+			100,
+		)
+		cache.CheckDuplicate(&key, 1000, 10, 1)
+	}
+
+	if cache.Size() != 10 {
+		t.Errorf("Expected size 10, got %d", cache.Size())
+	}
+
+	cache.Clear()
+
+	if cache.Size() != 0 {
+		t.Errorf("Expected size 0 after clear, got %d", cache.Size())
+	}
+}
+
+func TestMakeFlowKey_IPv4(t *testing.T) {
+	key := MakeFlowKey(
+		net.ParseIP("192.168.1.1"),
+		net.ParseIP("192.168.1.2"),
+		12345, 80, 6,
+		net.ParseIP("10.0.0.1"),
+		100,
+	)
+
+	if key.SrcPort != 12345 {
+		t.Errorf("Expected src port 12345, got %d", key.SrcPort)
+	}
+	if key.DstPort != 80 {
+		t.Errorf("Expected dst port 80, got %d", key.DstPort)
+	}
+	if key.Protocol != 6 {
+		t.Errorf("Expected protocol 6, got %d", key.Protocol)
+	}
+}
+
+func TestMakeFlowKey_IPv6(t *testing.T) {
+	key := MakeFlowKey(
+		net.ParseIP("2001:db8::1"),
+		net.ParseIP("2001:db8::2"),
+		12345, 443, 6,
+		net.ParseIP("2001:db8::100"),
+		200,
+	)
+
+	if key.SrcPort != 12345 {
+		t.Errorf("Expected src port 12345, got %d", key.SrcPort)
+	}
+	if key.SourceID != 200 {
+		t.Errorf("Expected source ID 200, got %d", key.SourceID)
+	}
+}
+
+func TestFlowKey_Hash(t *testing.T) {
+	key1 := MakeFlowKey(
+		net.ParseIP("192.168.1.1"),
+		net.ParseIP("192.168.1.2"),
+		12345, 80, 6,
+		net.ParseIP("10.0.0.1"),
+		100,
+	)
+
+	key2 := MakeFlowKey(
+		net.ParseIP("192.168.1.1"),
+		net.ParseIP("192.168.1.2"),
+		12345, 80, 6,
+		net.ParseIP("10.0.0.1"),
+		100,
+	)
+
+	key3 := MakeFlowKey(
+		net.ParseIP("192.168.1.1"),
+		net.ParseIP("192.168.1.3"), // Different
+		12345, 80, 6,
+		net.ParseIP("10.0.0.1"),
+		100,
+	)
+
+	if key1.Hash() != key2.Hash() {
+		t.Error("Same keys should have same hash")
+	}
+
+	if key1.Hash() == key3.Hash() {
+		t.Error("Different keys should have different hash")
+	}
+}
+
+func BenchmarkDedupCache_CheckDuplicate(b *testing.B) {
+	cache := NewDedupCache(&DedupCacheConfig{
+		MaxSize: 100000,
+		TTL:     time.Minute,
+	})
+	defer cache.Stop()
+
+	key := MakeFlowKey(
+		net.ParseIP("192.168.1.1"),
+		net.ParseIP("192.168.1.2"),
+		12345, 80, 6,
+		net.ParseIP("10.0.0.1"),
+		100,
+	)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.CheckDuplicate(&key, uint64(i), uint64(i), uint64(i))
+	}
+}
+
+func BenchmarkDedupCache_ManyFlows(b *testing.B) {
+	cache := NewDedupCache(&DedupCacheConfig{
+		MaxSize: 100000,
+		TTL:     time.Minute,
+	})
+	defer cache.Stop()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := MakeFlowKey(
+			net.ParseIP("192.168.1.1"),
+			net.IP{192, 168, byte(i >> 8), byte(i)},
+			uint16(i%65535), 80, 6,
+			net.ParseIP("10.0.0.1"),
+			100,
+		)
+		cache.CheckDuplicate(&key, 1000, 10, uint64(i))
+	}
+}

--- a/sampling/tracker.go
+++ b/sampling/tracker.go
@@ -1,0 +1,299 @@
+package sampling
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sirupsen/logrus"
+)
+
+var log *logrus.Logger
+
+func SetLogger(l *logrus.Logger) {
+	log = l
+}
+
+// SamplingAlgorithm represents the IPFIX sampling algorithm types
+type SamplingAlgorithm uint8
+
+const (
+	SamplingUnknown            SamplingAlgorithm = 0
+	SamplingDeterministic      SamplingAlgorithm = 1 // Systematic count-based (1:N)
+	SamplingRandom             SamplingAlgorithm = 2 // Random n-out-of-N
+	SamplingUniformProbability SamplingAlgorithm = 3 // Uniform probabilistic
+	SamplingPropertyMatch      SamplingAlgorithm = 4 // Property match
+	SamplingHashBased          SamplingAlgorithm = 5 // Hash-based
+)
+
+// SamplingInfo holds sampling configuration for an exporter
+type SamplingInfo struct {
+	Rate         uint32            // Sampling rate (1:N means rate=N)
+	Algorithm    SamplingAlgorithm // Algorithm used
+	Source       SamplingSource    // Where the sampling info came from
+	LastUpdated  time.Time         // When this info was last updated
+	ExporterIP   net.IP            // Exporter address
+	ExporterPort uint32            // Observation domain / source ID
+}
+
+// SamplingSource indicates where sampling information was obtained
+type SamplingSource uint8
+
+const (
+	SourceUnknown      SamplingSource = 0
+	SourceIPFIXOptions SamplingSource = 1 // From IPFIX options template
+	SourceNetFlowV9    SamplingSource = 2 // From NetFlow v9 options
+	SourceSFlowHeader  SamplingSource = 3 // From sFlow datagram header
+	SourceManual       SamplingSource = 4 // Manually configured
+)
+
+func (s SamplingSource) String() string {
+	switch s {
+	case SourceIPFIXOptions:
+		return "ipfix_options"
+	case SourceNetFlowV9:
+		return "netflow_v9"
+	case SourceSFlowHeader:
+		return "sflow_header"
+	case SourceManual:
+		return "manual"
+	default:
+		return "unknown"
+	}
+}
+
+// ExporterSamplingKey uniquely identifies a sampling context
+type ExporterSamplingKey struct {
+	IP             string
+	ObservationDom uint32
+}
+
+// SamplingTracker tracks sampling rates per exporter
+type SamplingTracker struct {
+	exporters     map[ExporterSamplingKey]*SamplingInfo
+	mu            sync.RWMutex
+	defaultRate   uint32 // Default rate if not known (1 = no sampling)
+	scalingEnabled bool  // Whether to apply scaling
+	metrics       *SamplingMetrics
+}
+
+// SamplingMetrics holds prometheus metrics for sampling tracking
+type SamplingMetrics struct {
+	SamplingRate       *prometheus.GaugeVec
+	ScaledBytes        *prometheus.CounterVec
+	ScaledPackets      *prometheus.CounterVec
+	SamplingInfoSource *prometheus.GaugeVec
+}
+
+// NewSamplingMetrics creates prometheus metrics for sampling
+func NewSamplingMetrics(namespace string) *SamplingMetrics {
+	return &SamplingMetrics{
+		SamplingRate: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "sampling",
+			Name:      "rate",
+			Help:      "Current sampling rate per exporter (1:N)",
+		}, []string{"exporter_ip", "observation_domain", "source"}),
+		ScaledBytes: promauto.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "sampling",
+			Name:      "scaled_bytes_total",
+			Help:      "Total bytes after upscaling",
+		}, []string{"exporter_ip"}),
+		ScaledPackets: promauto.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "sampling",
+			Name:      "scaled_packets_total",
+			Help:      "Total packets after upscaling",
+		}, []string{"exporter_ip"}),
+		SamplingInfoSource: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "sampling",
+			Name:      "info_source",
+			Help:      "Source of sampling information (1=ipfix, 2=netflow, 3=sflow, 4=manual)",
+		}, []string{"exporter_ip", "observation_domain"}),
+	}
+}
+
+// SamplingTrackerConfig holds configuration for the sampling tracker
+type SamplingTrackerConfig struct {
+	DefaultRate    uint32          // Default sampling rate (1 = no sampling)
+	ScalingEnabled bool            // Whether to apply upscaling
+	Metrics        *SamplingMetrics
+}
+
+// NewSamplingTracker creates a new sampling tracker
+func NewSamplingTracker(cfg *SamplingTrackerConfig) *SamplingTracker {
+	defaultRate := cfg.DefaultRate
+	if defaultRate == 0 {
+		defaultRate = 1 // No sampling by default
+	}
+
+	return &SamplingTracker{
+		exporters:      make(map[ExporterSamplingKey]*SamplingInfo),
+		defaultRate:    defaultRate,
+		scalingEnabled: cfg.ScalingEnabled,
+		metrics:        cfg.Metrics,
+	}
+}
+
+// UpdateSamplingRate updates the sampling rate for an exporter
+func (t *SamplingTracker) UpdateSamplingRate(ip net.IP, observationDom uint32, rate uint32, algorithm SamplingAlgorithm, source SamplingSource) {
+	if rate == 0 {
+		rate = 1 // Treat 0 as no sampling
+	}
+
+	key := ExporterSamplingKey{
+		IP:             ip.String(),
+		ObservationDom: observationDom,
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	info, exists := t.exporters[key]
+	if !exists {
+		info = &SamplingInfo{
+			ExporterIP:   ip,
+			ExporterPort: observationDom,
+		}
+		t.exporters[key] = info
+	}
+
+	oldRate := info.Rate
+	info.Rate = rate
+	info.Algorithm = algorithm
+	info.Source = source
+	info.LastUpdated = time.Now()
+
+	if t.metrics != nil {
+		labels := prometheus.Labels{
+			"exporter_ip":        ip.String(),
+			"observation_domain": string(rune(observationDom)),
+			"source":             source.String(),
+		}
+		t.metrics.SamplingRate.With(labels).Set(float64(rate))
+
+		srcLabels := prometheus.Labels{
+			"exporter_ip":        ip.String(),
+			"observation_domain": string(rune(observationDom)),
+		}
+		t.metrics.SamplingInfoSource.With(srcLabels).Set(float64(source))
+	}
+
+	if log != nil && (oldRate != rate || !exists) {
+		log.WithFields(logrus.Fields{
+			"exporter":           ip.String(),
+			"observation_domain": observationDom,
+			"rate":               rate,
+			"algorithm":          algorithm,
+			"source":             source.String(),
+		}).Info("Sampling rate updated")
+	}
+}
+
+// GetSamplingRate returns the sampling rate for an exporter
+func (t *SamplingTracker) GetSamplingRate(ip net.IP, observationDom uint32) *SamplingInfo {
+	key := ExporterSamplingKey{
+		IP:             ip.String(),
+		ObservationDom: observationDom,
+	}
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if info, ok := t.exporters[key]; ok {
+		// Return a copy to avoid race conditions
+		copyInfo := *info
+		return &copyInfo
+	}
+
+	// Return default info
+	return &SamplingInfo{
+		Rate:       t.defaultRate,
+		Algorithm:  SamplingUnknown,
+		Source:     SourceUnknown,
+		ExporterIP: ip,
+	}
+}
+
+// ScaleFlow applies sampling upscaling to bytes and packets
+// Returns the scaled values. If scaling is disabled, returns original values
+func (t *SamplingTracker) ScaleFlow(ip net.IP, observationDom uint32, bytes, packets uint64) (scaledBytes, scaledPackets uint64) {
+	if !t.scalingEnabled {
+		return bytes, packets
+	}
+
+	info := t.GetSamplingRate(ip, observationDom)
+	rate := uint64(info.Rate)
+	if rate <= 1 {
+		return bytes, packets
+	}
+
+	scaledBytes = bytes * rate
+	scaledPackets = packets * rate
+
+	if t.metrics != nil {
+		labels := prometheus.Labels{"exporter_ip": ip.String()}
+		t.metrics.ScaledBytes.With(labels).Add(float64(scaledBytes - bytes))
+		t.metrics.ScaledPackets.With(labels).Add(float64(scaledPackets - packets))
+	}
+
+	return scaledBytes, scaledPackets
+}
+
+// SetScalingEnabled enables or disables sampling upscaling
+func (t *SamplingTracker) SetScalingEnabled(enabled bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.scalingEnabled = enabled
+	if log != nil {
+		log.WithField("enabled", enabled).Info("Sampling upscaling toggled")
+	}
+}
+
+// IsScalingEnabled returns whether scaling is enabled
+func (t *SamplingTracker) IsScalingEnabled() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.scalingEnabled
+}
+
+// GetAllSamplingInfo returns a snapshot of all sampling information
+func (t *SamplingTracker) GetAllSamplingInfo() map[ExporterSamplingKey]SamplingInfo {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	result := make(map[ExporterSamplingKey]SamplingInfo, len(t.exporters))
+	for k, v := range t.exporters {
+		result[k] = *v
+	}
+	return result
+}
+
+// SetManualRate sets a manual sampling rate override for an exporter
+func (t *SamplingTracker) SetManualRate(ip net.IP, observationDom uint32, rate uint32) {
+	t.UpdateSamplingRate(ip, observationDom, rate, SamplingUnknown, SourceManual)
+}
+
+// ClearExporter removes sampling information for an exporter
+func (t *SamplingTracker) ClearExporter(ip net.IP, observationDom uint32) {
+	key := ExporterSamplingKey{
+		IP:             ip.String(),
+		ObservationDom: observationDom,
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	delete(t.exporters, key)
+
+	if log != nil {
+		log.WithFields(logrus.Fields{
+			"exporter":           ip.String(),
+			"observation_domain": observationDom,
+		}).Info("Sampling info cleared")
+	}
+}

--- a/sampling/tracker_test.go
+++ b/sampling/tracker_test.go
@@ -1,0 +1,239 @@
+package sampling
+
+import (
+	"net"
+	"testing"
+)
+
+func TestSamplingTracker_UpdateAndGet(t *testing.T) {
+	tracker := NewSamplingTracker(&SamplingTrackerConfig{
+		DefaultRate:    1,
+		ScalingEnabled: true,
+	})
+
+	ip := net.ParseIP("192.168.1.1")
+	observationDom := uint32(100)
+
+	// Initially should return default
+	info := tracker.GetSamplingRate(ip, observationDom)
+	if info.Rate != 1 {
+		t.Errorf("Expected default rate 1, got %d", info.Rate)
+	}
+	if info.Source != SourceUnknown {
+		t.Errorf("Expected source Unknown, got %v", info.Source)
+	}
+
+	// Update sampling rate
+	tracker.UpdateSamplingRate(ip, observationDom, 100, SamplingDeterministic, SourceIPFIXOptions)
+
+	info = tracker.GetSamplingRate(ip, observationDom)
+	if info.Rate != 100 {
+		t.Errorf("Expected rate 100, got %d", info.Rate)
+	}
+	if info.Source != SourceIPFIXOptions {
+		t.Errorf("Expected source IPFIXOptions, got %v", info.Source)
+	}
+	if info.Algorithm != SamplingDeterministic {
+		t.Errorf("Expected algorithm Deterministic, got %v", info.Algorithm)
+	}
+}
+
+func TestSamplingTracker_ScaleFlow(t *testing.T) {
+	tracker := NewSamplingTracker(&SamplingTrackerConfig{
+		DefaultRate:    1,
+		ScalingEnabled: true,
+	})
+
+	ip := net.ParseIP("192.168.1.1")
+	observationDom := uint32(100)
+
+	// Set sampling rate
+	tracker.UpdateSamplingRate(ip, observationDom, 10, SamplingDeterministic, SourceSFlowHeader)
+
+	// Scale flow
+	bytes := uint64(1000)
+	packets := uint64(5)
+
+	scaledBytes, scaledPackets := tracker.ScaleFlow(ip, observationDom, bytes, packets)
+
+	if scaledBytes != 10000 {
+		t.Errorf("Expected scaled bytes 10000, got %d", scaledBytes)
+	}
+	if scaledPackets != 50 {
+		t.Errorf("Expected scaled packets 50, got %d", scaledPackets)
+	}
+}
+
+func TestSamplingTracker_ScalingDisabled(t *testing.T) {
+	tracker := NewSamplingTracker(&SamplingTrackerConfig{
+		DefaultRate:    1,
+		ScalingEnabled: false,
+	})
+
+	ip := net.ParseIP("192.168.1.1")
+	observationDom := uint32(100)
+
+	// Set sampling rate
+	tracker.UpdateSamplingRate(ip, observationDom, 10, SamplingDeterministic, SourceSFlowHeader)
+
+	// Scale flow - should NOT scale when disabled
+	bytes := uint64(1000)
+	packets := uint64(5)
+
+	scaledBytes, scaledPackets := tracker.ScaleFlow(ip, observationDom, bytes, packets)
+
+	if scaledBytes != 1000 {
+		t.Errorf("Expected bytes 1000 (unscaled), got %d", scaledBytes)
+	}
+	if scaledPackets != 5 {
+		t.Errorf("Expected packets 5 (unscaled), got %d", scaledPackets)
+	}
+}
+
+func TestSamplingTracker_ZeroSampleRate(t *testing.T) {
+	tracker := NewSamplingTracker(&SamplingTrackerConfig{
+		DefaultRate:    1,
+		ScalingEnabled: true,
+	})
+
+	ip := net.ParseIP("192.168.1.1")
+	observationDom := uint32(100)
+
+	// Update with zero rate - should be treated as 1
+	tracker.UpdateSamplingRate(ip, observationDom, 0, SamplingUnknown, SourceSFlowHeader)
+
+	info := tracker.GetSamplingRate(ip, observationDom)
+	if info.Rate != 1 {
+		t.Errorf("Expected rate 1 (zero converted), got %d", info.Rate)
+	}
+}
+
+func TestSamplingTracker_MultipleExporters(t *testing.T) {
+	tracker := NewSamplingTracker(&SamplingTrackerConfig{
+		DefaultRate:    1,
+		ScalingEnabled: true,
+	})
+
+	ip1 := net.ParseIP("192.168.1.1")
+	ip2 := net.ParseIP("192.168.1.2")
+
+	tracker.UpdateSamplingRate(ip1, 100, 10, SamplingDeterministic, SourceIPFIXOptions)
+	tracker.UpdateSamplingRate(ip2, 100, 50, SamplingRandom, SourceSFlowHeader)
+	tracker.UpdateSamplingRate(ip1, 200, 25, SamplingDeterministic, SourceNetFlowV9)
+
+	info1 := tracker.GetSamplingRate(ip1, 100)
+	info2 := tracker.GetSamplingRate(ip2, 100)
+	info3 := tracker.GetSamplingRate(ip1, 200)
+
+	if info1.Rate != 10 {
+		t.Errorf("Expected rate 10 for ip1:100, got %d", info1.Rate)
+	}
+	if info2.Rate != 50 {
+		t.Errorf("Expected rate 50 for ip2:100, got %d", info2.Rate)
+	}
+	if info3.Rate != 25 {
+		t.Errorf("Expected rate 25 for ip1:200, got %d", info3.Rate)
+	}
+}
+
+func TestSamplingTracker_ManualOverride(t *testing.T) {
+	tracker := NewSamplingTracker(&SamplingTrackerConfig{
+		DefaultRate:    1,
+		ScalingEnabled: true,
+	})
+
+	ip := net.ParseIP("192.168.1.1")
+
+	// Set via protocol
+	tracker.UpdateSamplingRate(ip, 100, 10, SamplingDeterministic, SourceIPFIXOptions)
+
+	// Override manually
+	tracker.SetManualRate(ip, 100, 500)
+
+	info := tracker.GetSamplingRate(ip, 100)
+	if info.Rate != 500 {
+		t.Errorf("Expected manual rate 500, got %d", info.Rate)
+	}
+	if info.Source != SourceManual {
+		t.Errorf("Expected source Manual, got %v", info.Source)
+	}
+}
+
+func TestSamplingTracker_ClearExporter(t *testing.T) {
+	tracker := NewSamplingTracker(&SamplingTrackerConfig{
+		DefaultRate:    1,
+		ScalingEnabled: true,
+	})
+
+	ip := net.ParseIP("192.168.1.1")
+	tracker.UpdateSamplingRate(ip, 100, 50, SamplingDeterministic, SourceIPFIXOptions)
+
+	// Verify it's set
+	info := tracker.GetSamplingRate(ip, 100)
+	if info.Rate != 50 {
+		t.Error("Rate not set correctly")
+	}
+
+	// Clear
+	tracker.ClearExporter(ip, 100)
+
+	// Should return default now
+	info = tracker.GetSamplingRate(ip, 100)
+	if info.Rate != 1 {
+		t.Errorf("Expected default rate 1 after clear, got %d", info.Rate)
+	}
+	if info.Source != SourceUnknown {
+		t.Errorf("Expected source Unknown after clear, got %v", info.Source)
+	}
+}
+
+func TestSamplingTracker_GetAllSamplingInfo(t *testing.T) {
+	tracker := NewSamplingTracker(&SamplingTrackerConfig{
+		DefaultRate:    1,
+		ScalingEnabled: true,
+	})
+
+	ip1 := net.ParseIP("192.168.1.1")
+	ip2 := net.ParseIP("192.168.1.2")
+
+	tracker.UpdateSamplingRate(ip1, 100, 10, SamplingDeterministic, SourceIPFIXOptions)
+	tracker.UpdateSamplingRate(ip2, 200, 20, SamplingRandom, SourceSFlowHeader)
+
+	all := tracker.GetAllSamplingInfo()
+
+	if len(all) != 2 {
+		t.Errorf("Expected 2 exporters, got %d", len(all))
+	}
+}
+
+func TestSamplingTracker_ToggleScaling(t *testing.T) {
+	tracker := NewSamplingTracker(&SamplingTrackerConfig{
+		DefaultRate:    1,
+		ScalingEnabled: true,
+	})
+
+	if !tracker.IsScalingEnabled() {
+		t.Error("Scaling should be enabled initially")
+	}
+
+	tracker.SetScalingEnabled(false)
+
+	if tracker.IsScalingEnabled() {
+		t.Error("Scaling should be disabled after toggle")
+	}
+}
+
+func BenchmarkSamplingTracker_ScaleFlow(b *testing.B) {
+	tracker := NewSamplingTracker(&SamplingTrackerConfig{
+		DefaultRate:    1,
+		ScalingEnabled: true,
+	})
+
+	ip := net.ParseIP("192.168.1.1")
+	tracker.UpdateSamplingRate(ip, 100, 128, SamplingDeterministic, SourceIPFIXOptions)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tracker.ScaleFlow(ip, 100, 1500, 1)
+	}
+}

--- a/sflow/collector.go
+++ b/sflow/collector.go
@@ -1,0 +1,320 @@
+package sflow
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	flowpb "github.com/netsampler/goflow2/v2/pb"
+	"github.com/synfinatic/netflow2ng/collector"
+	"github.com/synfinatic/netflow2ng/sampling"
+)
+
+// SFlowCollector handles sFlow v5 packet collection
+type SFlowCollector struct {
+	listenAddr      string
+	listenPort      int
+	decoder         *Decoder
+	samplingTracker *sampling.SamplingTracker
+	workerPool      *collector.WorkerPool
+	conn            *net.UDPConn
+	ctx             context.Context
+	cancel          context.CancelFunc
+	wg              sync.WaitGroup
+	flowHandler     FlowHandler
+	metrics         *SFlowMetrics
+}
+
+// FlowHandler is called for each decoded sFlow message
+type FlowHandler func(*FlowMessage) error
+
+// SFlowMetrics holds prometheus metrics for sFlow collection
+type SFlowMetrics struct {
+	DatagramsReceived prometheus.Counter
+	SamplesDecoded    prometheus.Counter
+	FlowsProduced     prometheus.Counter
+	DecodeErrors      prometheus.Counter
+	BytesReceived     prometheus.Counter
+}
+
+// NewSFlowMetrics creates prometheus metrics for sFlow collection
+func NewSFlowMetrics(namespace string) *SFlowMetrics {
+	return &SFlowMetrics{
+		DatagramsReceived: promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "sflow",
+			Name:      "datagrams_received_total",
+			Help:      "Total sFlow datagrams received",
+		}),
+		SamplesDecoded: promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "sflow",
+			Name:      "samples_decoded_total",
+			Help:      "Total sFlow samples decoded",
+		}),
+		FlowsProduced: promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "sflow",
+			Name:      "flows_produced_total",
+			Help:      "Total flow messages produced from sFlow",
+		}),
+		DecodeErrors: promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "sflow",
+			Name:      "decode_errors_total",
+			Help:      "Total sFlow decode errors",
+		}),
+		BytesReceived: promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "sflow",
+			Name:      "bytes_received_total",
+			Help:      "Total bytes received from sFlow",
+		}),
+	}
+}
+
+// SFlowCollectorConfig holds configuration for the sFlow collector
+type SFlowCollectorConfig struct {
+	ListenAddr      string
+	ListenPort      int
+	NumWorkers      int
+	QueueSize       int
+	SamplingTracker *sampling.SamplingTracker
+	FlowHandler     FlowHandler
+	Metrics         *SFlowMetrics
+	PoolMetrics     *collector.PoolMetrics
+}
+
+// NewSFlowCollector creates a new sFlow collector
+func NewSFlowCollector(cfg *SFlowCollectorConfig) *SFlowCollector {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	c := &SFlowCollector{
+		listenAddr:      cfg.ListenAddr,
+		listenPort:      cfg.ListenPort,
+		decoder:         NewDecoder(cfg.SamplingTracker),
+		samplingTracker: cfg.SamplingTracker,
+		ctx:             ctx,
+		cancel:          cancel,
+		flowHandler:     cfg.FlowHandler,
+		metrics:         cfg.Metrics,
+	}
+
+	// Create worker pool
+	poolCfg := &collector.WorkerPoolConfig{
+		NumWorkers:    cfg.NumWorkers,
+		QueueSize:     cfg.QueueSize,
+		MaxPacketSize: 65535,
+		Handler:       c.processPacket,
+		Metrics:       cfg.PoolMetrics,
+	}
+	c.workerPool = collector.NewWorkerPool(poolCfg)
+
+	return c
+}
+
+// Start starts the sFlow collector
+func (c *SFlowCollector) Start() error {
+	addr := &net.UDPAddr{
+		IP:   net.ParseIP(c.listenAddr),
+		Port: c.listenPort,
+	}
+
+	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s:%d: %w", c.listenAddr, c.listenPort, err)
+	}
+	c.conn = conn
+
+	// Set receive buffer size
+	if err := conn.SetReadBuffer(16 * 1024 * 1024); err != nil {
+		if log != nil {
+			log.WithError(err).Warn("Failed to set UDP receive buffer size")
+		}
+	}
+
+	// Start worker pool
+	c.workerPool.Start()
+
+	// Start receiver goroutine
+	c.wg.Add(1)
+	go c.receiveLoop()
+
+	if log != nil {
+		log.WithField("addr", addr.String()).Info("sFlow collector started")
+	}
+
+	return nil
+}
+
+func (c *SFlowCollector) receiveLoop() {
+	defer c.wg.Done()
+
+	buf := make([]byte, 65535)
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		default:
+		}
+
+		// Set read deadline to allow periodic context checks
+		c.conn.SetReadDeadline(time.Now().Add(time.Second))
+
+		n, remoteAddr, err := c.conn.ReadFromUDP(buf)
+		if err != nil {
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				continue
+			}
+			if c.ctx.Err() != nil {
+				return
+			}
+			if log != nil {
+				log.WithError(err).Error("Error reading UDP packet")
+			}
+			continue
+		}
+
+		if c.metrics != nil {
+			c.metrics.BytesReceived.Add(float64(n))
+		}
+
+		// Submit to worker pool
+		c.workerPool.Submit(buf[:n], n, remoteAddr)
+	}
+}
+
+func (c *SFlowCollector) processPacket(ctx context.Context, work *collector.PacketWork) error {
+	// Extract source address
+	var srcIP net.IP
+	if udpAddr, ok := work.RemoteAddr.(*net.UDPAddr); ok {
+		srcIP = udpAddr.IP
+	}
+
+	// Decode the datagram
+	dg, err := c.decoder.DecodeDatagram(work.Data, srcIP)
+	if err != nil {
+		if c.metrics != nil {
+			c.metrics.DecodeErrors.Inc()
+		}
+		return err
+	}
+
+	if c.metrics != nil {
+		c.metrics.DatagramsReceived.Inc()
+		c.metrics.SamplesDecoded.Add(float64(len(dg.Samples)))
+	}
+
+	// Convert to flow messages
+	messages := c.decoder.ToFlowMessages(dg)
+
+	// Process each flow message
+	for _, msg := range messages {
+		if c.flowHandler != nil {
+			if err := c.flowHandler(msg); err != nil {
+				if log != nil {
+					log.WithError(err).Debug("Error handling sFlow message")
+				}
+			} else if c.metrics != nil {
+				c.metrics.FlowsProduced.Inc()
+			}
+		}
+	}
+
+	return nil
+}
+
+// Stop stops the sFlow collector
+func (c *SFlowCollector) Stop() error {
+	c.cancel()
+
+	if c.conn != nil {
+		c.conn.Close()
+	}
+
+	c.workerPool.Stop()
+	c.wg.Wait()
+
+	if log != nil {
+		log.Info("sFlow collector stopped")
+	}
+
+	return nil
+}
+
+// GetQueueDepth returns the current queue depth
+func (c *SFlowCollector) GetQueueDepth() int {
+	return c.workerPool.QueueLen()
+}
+
+// ConvertToGoflowMessage converts our sFlow message to goflow2's FlowMessage format
+// This allows reuse of the existing formatters
+func ConvertToGoflowMessage(msg *FlowMessage) *flowpb.FlowMessage {
+	fm := &flowpb.FlowMessage{
+		Type:             flowpb.FlowMessage_SFLOW_5,
+		TimeFlowStartNs:  msg.TimeFlowStartNs,
+		TimeFlowEndNs:    msg.TimeFlowEndNs,
+		Bytes:            msg.Bytes,
+		Packets:          msg.Packets,
+		SrcPort:          uint32(msg.SrcPort),
+		DstPort:          uint32(msg.DstPort),
+		Proto:            uint32(msg.Protocol),
+		Etype:            uint32(msg.EtherType),
+		InIf:             msg.InIf,
+		OutIf:            msg.OutIf,
+		SrcMac:           msg.SrcMAC,
+		DstMac:           msg.DstMAC,
+		SrcVlan:          msg.SrcVLAN,
+		DstVlan:          msg.DstVLAN,
+		IpTos:            uint32(msg.ToS),
+		IpTtl:            uint32(msg.TTL),
+		TcpFlags:         uint32(msg.TCPFlags),
+		IcmpType:         uint32(msg.IcmpType),
+		IcmpCode:         uint32(msg.IcmpCode),
+		FragmentOffset:   uint32(msg.FragmentOffset),
+		FragmentId:       msg.FragmentId,
+		Ipv6FlowLabel:    msg.IPv6FlowLabel,
+		SrcNet:           msg.SrcNet,
+		DstNet:           msg.DstNet,
+		SamplingRate:     uint64(msg.SamplingRate),
+	}
+
+	// Set addresses
+	if msg.SrcAddr != nil {
+		if ip4 := msg.SrcAddr.To4(); ip4 != nil {
+			fm.SrcAddr = ip4
+		} else {
+			fm.SrcAddr = msg.SrcAddr.To16()
+		}
+	}
+
+	if msg.DstAddr != nil {
+		if ip4 := msg.DstAddr.To4(); ip4 != nil {
+			fm.DstAddr = ip4
+		} else {
+			fm.DstAddr = msg.DstAddr.To16()
+		}
+	}
+
+	if msg.NextHop != nil {
+		if ip4 := msg.NextHop.To4(); ip4 != nil {
+			fm.NextHop = ip4
+		} else {
+			fm.NextHop = msg.NextHop.To16()
+		}
+	}
+
+	if msg.SamplerAddress != nil {
+		if ip4 := msg.SamplerAddress.To4(); ip4 != nil {
+			fm.SamplerAddress = ip4
+		} else {
+			fm.SamplerAddress = msg.SamplerAddress.To16()
+		}
+	}
+
+	return fm
+}

--- a/sflow/decoder.go
+++ b/sflow/decoder.go
@@ -1,0 +1,728 @@
+package sflow
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/synfinatic/netflow2ng/sampling"
+)
+
+var log *logrus.Logger
+
+func SetLogger(l *logrus.Logger) {
+	log = l
+}
+
+// sFlow v5 constants
+const (
+	SFlowVersion5 = 5
+
+	// Sample types
+	SFlowTypeFlowSample         = 1
+	SFlowTypeCounterSample      = 2
+	SFlowTypeExpandedFlowSample = 3
+	SFlowTypeExpandedCounter    = 4
+
+	// Flow record types (enterprise = 0)
+	SFlowFlowRawPacketHeader    = 1
+	SFlowFlowEthernetFrame      = 2
+	SFlowFlowIPv4               = 3
+	SFlowFlowIPv6               = 4
+	SFlowFlowExtendedSwitch     = 1001
+	SFlowFlowExtendedRouter     = 1002
+	SFlowFlowExtendedGateway    = 1003
+	SFlowFlowExtendedUser       = 1004
+	SFlowFlowExtendedURL        = 1005
+	SFlowFlowExtendedMpls       = 1006
+	SFlowFlowExtendedNat        = 1007
+	SFlowFlowExtendedMplsTunnel = 1008
+	SFlowFlowExtendedMplsVC     = 1009
+	SFlowFlowExtendedMpls_FTN   = 1010
+	SFlowFlowExtendedMpls_LDP   = 1011
+	SFlowFlowExtendedVlanTunnel = 1012
+)
+
+// SFlowDatagram represents an sFlow v5 datagram
+type SFlowDatagram struct {
+	Version        uint32
+	AgentAddress   net.IP
+	SubAgentID     uint32
+	SequenceNumber uint32
+	SysUptime      uint32 // milliseconds since boot
+	NumSamples     uint32
+	Samples        []SFlowSample
+	ReceivedAt     time.Time
+}
+
+// SFlowSample is the interface for all sFlow sample types
+type SFlowSample interface {
+	GetType() uint32
+}
+
+// SFlowFlowSample represents a flow sample
+type SFlowFlowSample struct {
+	SequenceNumber   uint32
+	SourceID         uint32
+	SamplingRate     uint32
+	SamplePool       uint32
+	Drops            uint32
+	InputInterface   uint32
+	OutputInterface  uint32
+	NumFlowRecords   uint32
+	FlowRecords      []SFlowFlowRecord
+	// For expanded samples
+	SourceIDType  uint32
+	SourceIDIndex uint32
+}
+
+func (s *SFlowFlowSample) GetType() uint32 {
+	return SFlowTypeFlowSample
+}
+
+// SFlowFlowRecord represents a flow record within a sample
+type SFlowFlowRecord struct {
+	Enterprise uint32
+	Format     uint32
+	Length     uint32
+	Data       interface{} // Parsed record data
+}
+
+// SFlowRawPacketHeader represents a raw packet header record
+type SFlowRawPacketHeader struct {
+	Protocol       uint32 // Header protocol (1 = Ethernet)
+	FrameLength    uint32 // Original frame length
+	Stripped       uint32 // Bytes stripped from packet
+	HeaderLength   uint32
+	HeaderData     []byte
+	// Parsed from header
+	SrcMAC         net.HardwareAddr
+	DstMAC         net.HardwareAddr
+	EtherType      uint16
+	SrcIP          net.IP
+	DstIP          net.IP
+	SrcPort        uint16
+	DstPort        uint16
+	Protocol_L4    uint8
+	TCPFlags       uint8
+	SrcVLAN        uint16
+	DstVLAN        uint16
+	IPVersion      uint8
+	ToS            uint8
+	TTL            uint8
+	NextHop        net.IP
+	ICMP_Type      uint8
+	ICMP_Code      uint8
+	IPv6FlowLabel  uint32
+	FragmentOffset uint16
+	FragmentID     uint32
+}
+
+// SFlowExtendedSwitch represents extended switch data
+type SFlowExtendedSwitch struct {
+	SrcVLAN     uint32
+	SrcPriority uint32
+	DstVLAN     uint32
+	DstPriority uint32
+}
+
+// SFlowExtendedRouter represents extended router data
+type SFlowExtendedRouter struct {
+	NextHop   net.IP
+	SrcMask   uint32
+	DstMask   uint32
+}
+
+// FlowMessage represents a decoded flow that can be passed to formatters
+type FlowMessage struct {
+	// Core flow identification
+	SrcAddr    net.IP
+	DstAddr    net.IP
+	SrcPort    uint16
+	DstPort    uint16
+	Protocol   uint8
+	EtherType  uint16
+	IPVersion  uint8
+
+	// Statistics (will be upscaled by sampling rate)
+	Bytes      uint64
+	Packets    uint64
+
+	// Sampling info
+	SamplingRate uint32
+
+	// Timing
+	TimeFlowStartNs uint64
+	TimeFlowEndNs   uint64
+
+	// Interface info
+	InIf  uint32
+	OutIf uint32
+
+	// Layer 2
+	SrcMAC   uint64
+	DstMAC   uint64
+	SrcVLAN  uint32
+	DstVLAN  uint32
+
+	// Layer 3
+	ToS            uint8
+	TTL            uint8
+	TCPFlags       uint8
+	NextHop        net.IP
+	SrcNet         uint32
+	DstNet         uint32
+	FragmentOffset uint16
+	FragmentId     uint32
+	IPv6FlowLabel  uint32
+
+	// ICMP
+	IcmpType uint8
+	IcmpCode uint8
+
+	// Exporter info
+	SamplerAddress net.IP
+	SourceID       uint32
+	SequenceNumber uint32
+}
+
+// Decoder handles sFlow v5 decoding
+type Decoder struct {
+	samplingTracker *sampling.SamplingTracker
+}
+
+// NewDecoder creates a new sFlow decoder
+func NewDecoder(tracker *sampling.SamplingTracker) *Decoder {
+	return &Decoder{
+		samplingTracker: tracker,
+	}
+}
+
+// DecodeDatagram decodes an sFlow v5 datagram
+func (d *Decoder) DecodeDatagram(data []byte, srcAddr net.IP) (*SFlowDatagram, error) {
+	if len(data) < 28 {
+		return nil, fmt.Errorf("sflow datagram too short: %d bytes", len(data))
+	}
+
+	buf := bytes.NewReader(data)
+	dg := &SFlowDatagram{
+		ReceivedAt: time.Now(),
+	}
+
+	// Read header
+	if err := binary.Read(buf, binary.BigEndian, &dg.Version); err != nil {
+		return nil, fmt.Errorf("failed to read version: %w", err)
+	}
+
+	if dg.Version != SFlowVersion5 {
+		return nil, fmt.Errorf("unsupported sflow version: %d", dg.Version)
+	}
+
+	// Read agent address type
+	var agentAddrType uint32
+	if err := binary.Read(buf, binary.BigEndian, &agentAddrType); err != nil {
+		return nil, fmt.Errorf("failed to read agent address type: %w", err)
+	}
+
+	// Read agent address
+	switch agentAddrType {
+	case 1: // IPv4
+		addr := make([]byte, 4)
+		if _, err := buf.Read(addr); err != nil {
+			return nil, fmt.Errorf("failed to read IPv4 agent address: %w", err)
+		}
+		dg.AgentAddress = net.IP(addr)
+	case 2: // IPv6
+		addr := make([]byte, 16)
+		if _, err := buf.Read(addr); err != nil {
+			return nil, fmt.Errorf("failed to read IPv6 agent address: %w", err)
+		}
+		dg.AgentAddress = net.IP(addr)
+	default:
+		return nil, fmt.Errorf("unknown agent address type: %d", agentAddrType)
+	}
+
+	// Read remaining header fields
+	if err := binary.Read(buf, binary.BigEndian, &dg.SubAgentID); err != nil {
+		return nil, fmt.Errorf("failed to read sub-agent ID: %w", err)
+	}
+	if err := binary.Read(buf, binary.BigEndian, &dg.SequenceNumber); err != nil {
+		return nil, fmt.Errorf("failed to read sequence number: %w", err)
+	}
+	if err := binary.Read(buf, binary.BigEndian, &dg.SysUptime); err != nil {
+		return nil, fmt.Errorf("failed to read sys uptime: %w", err)
+	}
+	if err := binary.Read(buf, binary.BigEndian, &dg.NumSamples); err != nil {
+		return nil, fmt.Errorf("failed to read num samples: %w", err)
+	}
+
+	// Parse samples
+	dg.Samples = make([]SFlowSample, 0, dg.NumSamples)
+	for i := uint32(0); i < dg.NumSamples; i++ {
+		sample, err := d.decodeSample(buf)
+		if err != nil {
+			if log != nil {
+				log.WithError(err).Debug("Failed to decode sFlow sample")
+			}
+			// Try to continue with remaining samples
+			break
+		}
+		if sample != nil {
+			dg.Samples = append(dg.Samples, sample)
+		}
+	}
+
+	return dg, nil
+}
+
+func (d *Decoder) decodeSample(buf *bytes.Reader) (SFlowSample, error) {
+	var sampleType, sampleLength uint32
+
+	if err := binary.Read(buf, binary.BigEndian, &sampleType); err != nil {
+		return nil, fmt.Errorf("failed to read sample type: %w", err)
+	}
+	if err := binary.Read(buf, binary.BigEndian, &sampleLength); err != nil {
+		return nil, fmt.Errorf("failed to read sample length: %w", err)
+	}
+
+	// Extract enterprise and format from sample type
+	enterprise := sampleType >> 12
+	format := sampleType & 0xFFF
+
+	if enterprise != 0 {
+		// Skip enterprise-specific samples
+		buf.Seek(int64(sampleLength), 1)
+		return nil, nil
+	}
+
+	switch format {
+	case SFlowTypeFlowSample:
+		return d.decodeFlowSample(buf, false)
+	case SFlowTypeExpandedFlowSample:
+		return d.decodeFlowSample(buf, true)
+	case SFlowTypeCounterSample, SFlowTypeExpandedCounter:
+		// Skip counter samples for now (we're focused on flow data)
+		buf.Seek(int64(sampleLength), 1)
+		return nil, nil
+	default:
+		// Skip unknown sample types
+		buf.Seek(int64(sampleLength), 1)
+		return nil, nil
+	}
+}
+
+func (d *Decoder) decodeFlowSample(buf *bytes.Reader, expanded bool) (*SFlowFlowSample, error) {
+	sample := &SFlowFlowSample{}
+
+	if err := binary.Read(buf, binary.BigEndian, &sample.SequenceNumber); err != nil {
+		return nil, err
+	}
+
+	if expanded {
+		if err := binary.Read(buf, binary.BigEndian, &sample.SourceIDType); err != nil {
+			return nil, err
+		}
+		if err := binary.Read(buf, binary.BigEndian, &sample.SourceIDIndex); err != nil {
+			return nil, err
+		}
+		sample.SourceID = sample.SourceIDIndex
+	} else {
+		if err := binary.Read(buf, binary.BigEndian, &sample.SourceID); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := binary.Read(buf, binary.BigEndian, &sample.SamplingRate); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(buf, binary.BigEndian, &sample.SamplePool); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(buf, binary.BigEndian, &sample.Drops); err != nil {
+		return nil, err
+	}
+
+	if expanded {
+		var inputType, outputType uint32
+		if err := binary.Read(buf, binary.BigEndian, &inputType); err != nil {
+			return nil, err
+		}
+		if err := binary.Read(buf, binary.BigEndian, &sample.InputInterface); err != nil {
+			return nil, err
+		}
+		if err := binary.Read(buf, binary.BigEndian, &outputType); err != nil {
+			return nil, err
+		}
+		if err := binary.Read(buf, binary.BigEndian, &sample.OutputInterface); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := binary.Read(buf, binary.BigEndian, &sample.InputInterface); err != nil {
+			return nil, err
+		}
+		if err := binary.Read(buf, binary.BigEndian, &sample.OutputInterface); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := binary.Read(buf, binary.BigEndian, &sample.NumFlowRecords); err != nil {
+		return nil, err
+	}
+
+	// Parse flow records
+	sample.FlowRecords = make([]SFlowFlowRecord, 0, sample.NumFlowRecords)
+	for i := uint32(0); i < sample.NumFlowRecords; i++ {
+		record, err := d.decodeFlowRecord(buf)
+		if err != nil {
+			if log != nil {
+				log.WithError(err).Debug("Failed to decode flow record")
+			}
+			break
+		}
+		sample.FlowRecords = append(sample.FlowRecords, record)
+	}
+
+	return sample, nil
+}
+
+func (d *Decoder) decodeFlowRecord(buf *bytes.Reader) (SFlowFlowRecord, error) {
+	var record SFlowFlowRecord
+
+	var recordType uint32
+	if err := binary.Read(buf, binary.BigEndian, &recordType); err != nil {
+		return record, err
+	}
+	record.Enterprise = recordType >> 12
+	record.Format = recordType & 0xFFF
+
+	if err := binary.Read(buf, binary.BigEndian, &record.Length); err != nil {
+		return record, err
+	}
+
+	// Only parse standard (enterprise=0) records
+	if record.Enterprise != 0 {
+		buf.Seek(int64(record.Length), 1)
+		return record, nil
+	}
+
+	switch record.Format {
+	case SFlowFlowRawPacketHeader:
+		header, err := d.decodeRawPacketHeader(buf, record.Length)
+		if err != nil {
+			return record, err
+		}
+		record.Data = header
+	case SFlowFlowExtendedSwitch:
+		sw, err := d.decodeExtendedSwitch(buf)
+		if err != nil {
+			return record, err
+		}
+		record.Data = sw
+	case SFlowFlowExtendedRouter:
+		router, err := d.decodeExtendedRouter(buf)
+		if err != nil {
+			return record, err
+		}
+		record.Data = router
+	default:
+		// Skip unknown record types
+		buf.Seek(int64(record.Length), 1)
+	}
+
+	return record, nil
+}
+
+func (d *Decoder) decodeRawPacketHeader(buf *bytes.Reader, length uint32) (*SFlowRawPacketHeader, error) {
+	header := &SFlowRawPacketHeader{}
+
+	if err := binary.Read(buf, binary.BigEndian, &header.Protocol); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(buf, binary.BigEndian, &header.FrameLength); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(buf, binary.BigEndian, &header.Stripped); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(buf, binary.BigEndian, &header.HeaderLength); err != nil {
+		return nil, err
+	}
+
+	// Read header data (padded to 4-byte boundary)
+	paddedLen := (header.HeaderLength + 3) & ^uint32(3)
+	header.HeaderData = make([]byte, paddedLen)
+	if _, err := buf.Read(header.HeaderData); err != nil {
+		return nil, err
+	}
+	header.HeaderData = header.HeaderData[:header.HeaderLength]
+
+	// Parse the packet header (Ethernet)
+	if header.Protocol == 1 && len(header.HeaderData) >= 14 {
+		d.parseEthernetHeader(header)
+	}
+
+	return header, nil
+}
+
+func (d *Decoder) parseEthernetHeader(header *SFlowRawPacketHeader) {
+	data := header.HeaderData
+
+	// Ethernet header: 6 bytes dst MAC, 6 bytes src MAC, 2 bytes ethertype
+	if len(data) < 14 {
+		return
+	}
+
+	header.DstMAC = net.HardwareAddr(data[0:6])
+	header.SrcMAC = net.HardwareAddr(data[6:12])
+	header.EtherType = binary.BigEndian.Uint16(data[12:14])
+
+	offset := 14
+
+	// Handle VLAN tags (0x8100)
+	for header.EtherType == 0x8100 {
+		if len(data) < offset+4 {
+			return
+		}
+		vlanTag := binary.BigEndian.Uint16(data[offset : offset+2])
+		header.SrcVLAN = vlanTag & 0x0FFF
+		header.DstVLAN = header.SrcVLAN
+		header.EtherType = binary.BigEndian.Uint16(data[offset+2 : offset+4])
+		offset += 4
+	}
+
+	// Parse IP header
+	switch header.EtherType {
+	case 0x0800: // IPv4
+		header.IPVersion = 4
+		if len(data) < offset+20 {
+			return
+		}
+		header.ToS = data[offset+1]
+		header.TTL = data[offset+8]
+		header.Protocol_L4 = data[offset+9]
+		header.SrcIP = net.IP(data[offset+12 : offset+16])
+		header.DstIP = net.IP(data[offset+16 : offset+20])
+
+		ihl := int(data[offset]&0x0F) * 4
+		header.FragmentOffset = binary.BigEndian.Uint16(data[offset+6:offset+8]) & 0x1FFF
+		header.FragmentID = uint32(binary.BigEndian.Uint16(data[offset+4 : offset+6]))
+
+		// Parse L4 header
+		if len(data) >= offset+ihl+4 {
+			d.parseL4Header(header, data[offset+ihl:])
+		}
+
+	case 0x86DD: // IPv6
+		header.IPVersion = 6
+		if len(data) < offset+40 {
+			return
+		}
+		header.ToS = (data[offset] << 4) | (data[offset+1] >> 4)
+		header.IPv6FlowLabel = uint32(data[offset+1]&0x0F)<<16 | uint32(binary.BigEndian.Uint16(data[offset+2:offset+4]))
+		header.Protocol_L4 = data[offset+6]
+		header.TTL = data[offset+7]
+		header.SrcIP = net.IP(data[offset+8 : offset+24])
+		header.DstIP = net.IP(data[offset+24 : offset+40])
+
+		// Parse L4 header
+		if len(data) >= offset+40+4 {
+			d.parseL4Header(header, data[offset+40:])
+		}
+	}
+}
+
+func (d *Decoder) parseL4Header(header *SFlowRawPacketHeader, data []byte) {
+	if len(data) < 4 {
+		return
+	}
+
+	switch header.Protocol_L4 {
+	case 6: // TCP
+		header.SrcPort = binary.BigEndian.Uint16(data[0:2])
+		header.DstPort = binary.BigEndian.Uint16(data[2:4])
+		if len(data) >= 14 {
+			header.TCPFlags = data[13]
+		}
+	case 17: // UDP
+		header.SrcPort = binary.BigEndian.Uint16(data[0:2])
+		header.DstPort = binary.BigEndian.Uint16(data[2:4])
+	case 1: // ICMP
+		header.ICMP_Type = data[0]
+		header.ICMP_Code = data[1]
+	case 58: // ICMPv6
+		header.ICMP_Type = data[0]
+		header.ICMP_Code = data[1]
+	}
+}
+
+func (d *Decoder) decodeExtendedSwitch(buf *bytes.Reader) (*SFlowExtendedSwitch, error) {
+	sw := &SFlowExtendedSwitch{}
+
+	if err := binary.Read(buf, binary.BigEndian, &sw.SrcVLAN); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(buf, binary.BigEndian, &sw.SrcPriority); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(buf, binary.BigEndian, &sw.DstVLAN); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(buf, binary.BigEndian, &sw.DstPriority); err != nil {
+		return nil, err
+	}
+
+	return sw, nil
+}
+
+func (d *Decoder) decodeExtendedRouter(buf *bytes.Reader) (*SFlowExtendedRouter, error) {
+	router := &SFlowExtendedRouter{}
+
+	var addrType uint32
+	if err := binary.Read(buf, binary.BigEndian, &addrType); err != nil {
+		return nil, err
+	}
+
+	switch addrType {
+	case 1: // IPv4
+		addr := make([]byte, 4)
+		if _, err := buf.Read(addr); err != nil {
+			return nil, err
+		}
+		router.NextHop = net.IP(addr)
+	case 2: // IPv6
+		addr := make([]byte, 16)
+		if _, err := buf.Read(addr); err != nil {
+			return nil, err
+		}
+		router.NextHop = net.IP(addr)
+	}
+
+	if err := binary.Read(buf, binary.BigEndian, &router.SrcMask); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(buf, binary.BigEndian, &router.DstMask); err != nil {
+		return nil, err
+	}
+
+	return router, nil
+}
+
+// ToFlowMessages converts an sFlow datagram to flow messages
+func (d *Decoder) ToFlowMessages(dg *SFlowDatagram) []*FlowMessage {
+	var messages []*FlowMessage
+
+	for _, sample := range dg.Samples {
+		flowSample, ok := sample.(*SFlowFlowSample)
+		if !ok {
+			continue
+		}
+
+		// Update sampling tracker if we have one
+		if d.samplingTracker != nil && flowSample.SamplingRate > 0 {
+			d.samplingTracker.UpdateSamplingRate(
+				dg.AgentAddress,
+				flowSample.SourceID,
+				flowSample.SamplingRate,
+				sampling.SamplingDeterministic,
+				sampling.SourceSFlowHeader,
+			)
+		}
+
+		msg := d.flowSampleToMessage(dg, flowSample)
+		if msg != nil {
+			messages = append(messages, msg)
+		}
+	}
+
+	return messages
+}
+
+func (d *Decoder) flowSampleToMessage(dg *SFlowDatagram, sample *SFlowFlowSample) *FlowMessage {
+	msg := &FlowMessage{
+		SamplerAddress: dg.AgentAddress,
+		SourceID:       sample.SourceID,
+		SequenceNumber: dg.SequenceNumber,
+		SamplingRate:   sample.SamplingRate,
+		InIf:           sample.InputInterface,
+		OutIf:          sample.OutputInterface,
+		Packets:        1, // sFlow samples individual packets
+	}
+
+	now := time.Now().UnixNano()
+	msg.TimeFlowStartNs = uint64(now)
+	msg.TimeFlowEndNs = uint64(now)
+
+	// Process flow records
+	var rawHeader *SFlowRawPacketHeader
+	var extSwitch *SFlowExtendedSwitch
+	var extRouter *SFlowExtendedRouter
+
+	for _, record := range sample.FlowRecords {
+		switch data := record.Data.(type) {
+		case *SFlowRawPacketHeader:
+			rawHeader = data
+		case *SFlowExtendedSwitch:
+			extSwitch = data
+		case *SFlowExtendedRouter:
+			extRouter = data
+		}
+	}
+
+	if rawHeader == nil {
+		return nil // No usable packet data
+	}
+
+	// Fill in from raw header
+	msg.SrcAddr = rawHeader.SrcIP
+	msg.DstAddr = rawHeader.DstIP
+	msg.SrcPort = rawHeader.SrcPort
+	msg.DstPort = rawHeader.DstPort
+	msg.Protocol = rawHeader.Protocol_L4
+	msg.EtherType = rawHeader.EtherType
+	msg.IPVersion = rawHeader.IPVersion
+	msg.Bytes = uint64(rawHeader.FrameLength)
+	msg.ToS = rawHeader.ToS
+	msg.TTL = rawHeader.TTL
+	msg.TCPFlags = rawHeader.TCPFlags
+	msg.IcmpType = rawHeader.ICMP_Type
+	msg.IcmpCode = rawHeader.ICMP_Code
+	msg.FragmentOffset = rawHeader.FragmentOffset
+	msg.FragmentId = rawHeader.FragmentID
+	msg.IPv6FlowLabel = rawHeader.IPv6FlowLabel
+	msg.NextHop = rawHeader.NextHop
+	msg.SrcVLAN = uint32(rawHeader.SrcVLAN)
+	msg.DstVLAN = uint32(rawHeader.DstVLAN)
+
+	// Convert MAC addresses to uint64
+	if len(rawHeader.SrcMAC) == 6 {
+		msg.SrcMAC = macToUint64(rawHeader.SrcMAC)
+	}
+	if len(rawHeader.DstMAC) == 6 {
+		msg.DstMAC = macToUint64(rawHeader.DstMAC)
+	}
+
+	// Override with extended data if available
+	if extSwitch != nil {
+		msg.SrcVLAN = extSwitch.SrcVLAN
+		msg.DstVLAN = extSwitch.DstVLAN
+	}
+
+	if extRouter != nil {
+		msg.NextHop = extRouter.NextHop
+		msg.SrcNet = extRouter.SrcMask
+		msg.DstNet = extRouter.DstMask
+	}
+
+	return msg
+}
+
+func macToUint64(mac net.HardwareAddr) uint64 {
+	if len(mac) != 6 {
+		return 0
+	}
+	return uint64(mac[0])<<40 | uint64(mac[1])<<32 | uint64(mac[2])<<24 |
+		uint64(mac[3])<<16 | uint64(mac[4])<<8 | uint64(mac[5])
+}

--- a/sflow/decoder_test.go
+++ b/sflow/decoder_test.go
@@ -1,0 +1,319 @@
+package sflow
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+// buildSFlowDatagram creates a minimal sFlow v5 datagram for testing
+func buildSFlowDatagram(agentIP net.IP, subAgentID, seqNum uint32, samples []byte) []byte {
+	buf := new(bytes.Buffer)
+
+	// Version (5)
+	binary.Write(buf, binary.BigEndian, uint32(5))
+
+	// Agent address type and address
+	if agentIP.To4() != nil {
+		binary.Write(buf, binary.BigEndian, uint32(1)) // IPv4
+		buf.Write(agentIP.To4())
+	} else {
+		binary.Write(buf, binary.BigEndian, uint32(2)) // IPv6
+		buf.Write(agentIP.To16())
+	}
+
+	// Sub-agent ID
+	binary.Write(buf, binary.BigEndian, subAgentID)
+
+	// Sequence number
+	binary.Write(buf, binary.BigEndian, seqNum)
+
+	// System uptime (ms)
+	binary.Write(buf, binary.BigEndian, uint32(12345678))
+
+	// Number of samples
+	numSamples := uint32(0)
+	if len(samples) > 0 {
+		numSamples = 1
+	}
+	binary.Write(buf, binary.BigEndian, numSamples)
+
+	// Samples
+	buf.Write(samples)
+
+	return buf.Bytes()
+}
+
+// buildFlowSample creates a flow sample with raw packet header
+func buildFlowSample(samplingRate, inputIf, outputIf uint32, header []byte) []byte {
+	buf := new(bytes.Buffer)
+
+	// Sample type (1 = flow sample) | length placeholder
+	sampleType := uint32(1) // flow sample
+	binary.Write(buf, binary.BigEndian, sampleType)
+
+	// Sample data
+	sampleBuf := new(bytes.Buffer)
+
+	// Sequence number
+	binary.Write(sampleBuf, binary.BigEndian, uint32(1))
+
+	// Source ID
+	binary.Write(sampleBuf, binary.BigEndian, uint32(0))
+
+	// Sampling rate
+	binary.Write(sampleBuf, binary.BigEndian, samplingRate)
+
+	// Sample pool
+	binary.Write(sampleBuf, binary.BigEndian, uint32(1000))
+
+	// Drops
+	binary.Write(sampleBuf, binary.BigEndian, uint32(0))
+
+	// Input interface
+	binary.Write(sampleBuf, binary.BigEndian, inputIf)
+
+	// Output interface
+	binary.Write(sampleBuf, binary.BigEndian, outputIf)
+
+	// Number of flow records
+	binary.Write(sampleBuf, binary.BigEndian, uint32(1))
+
+	// Flow record (raw packet header)
+	recordBuf := new(bytes.Buffer)
+
+	// Protocol (1 = Ethernet)
+	binary.Write(recordBuf, binary.BigEndian, uint32(1))
+
+	// Frame length
+	binary.Write(recordBuf, binary.BigEndian, uint32(len(header)))
+
+	// Stripped
+	binary.Write(recordBuf, binary.BigEndian, uint32(0))
+
+	// Header length
+	binary.Write(recordBuf, binary.BigEndian, uint32(len(header)))
+
+	// Header data (padded to 4 bytes)
+	recordBuf.Write(header)
+	for recordBuf.Len()%4 != 0 {
+		recordBuf.WriteByte(0)
+	}
+
+	// Record type (1 = raw packet header) and length
+	binary.Write(sampleBuf, binary.BigEndian, uint32(1)) // record type
+	binary.Write(sampleBuf, binary.BigEndian, uint32(recordBuf.Len()+16)) // 16 for fields above
+	sampleBuf.Write(recordBuf.Bytes())
+
+	// Write sample length
+	binary.Write(buf, binary.BigEndian, uint32(sampleBuf.Len()))
+	buf.Write(sampleBuf.Bytes())
+
+	return buf.Bytes()
+}
+
+// buildEthernetIPv4TCPHeader builds a simple Ethernet + IPv4 + TCP header
+func buildEthernetIPv4TCPHeader(srcIP, dstIP net.IP, srcPort, dstPort uint16) []byte {
+	buf := new(bytes.Buffer)
+
+	// Ethernet header
+	// Dst MAC
+	buf.Write([]byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55})
+	// Src MAC
+	buf.Write([]byte{0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb})
+	// EtherType (IPv4)
+	binary.Write(buf, binary.BigEndian, uint16(0x0800))
+
+	// IPv4 header (20 bytes)
+	buf.WriteByte(0x45) // Version + IHL
+	buf.WriteByte(0x00) // ToS
+	binary.Write(buf, binary.BigEndian, uint16(40)) // Total length
+	binary.Write(buf, binary.BigEndian, uint16(0)) // Identification
+	binary.Write(buf, binary.BigEndian, uint16(0)) // Flags + Fragment offset
+	buf.WriteByte(64) // TTL
+	buf.WriteByte(6)  // Protocol (TCP)
+	binary.Write(buf, binary.BigEndian, uint16(0)) // Header checksum
+	buf.Write(srcIP.To4())
+	buf.Write(dstIP.To4())
+
+	// TCP header (at least 4 bytes for ports)
+	binary.Write(buf, binary.BigEndian, srcPort)
+	binary.Write(buf, binary.BigEndian, dstPort)
+	binary.Write(buf, binary.BigEndian, uint32(0)) // Seq
+	binary.Write(buf, binary.BigEndian, uint32(0)) // Ack
+	buf.WriteByte(0x50) // Data offset
+	buf.WriteByte(0x02) // Flags (SYN)
+	binary.Write(buf, binary.BigEndian, uint16(65535)) // Window
+
+	return buf.Bytes()
+}
+
+func TestDecoder_DecodeDatagram_Basic(t *testing.T) {
+	decoder := NewDecoder(nil)
+
+	agentIP := net.ParseIP("192.168.1.1")
+	data := buildSFlowDatagram(agentIP, 0, 1, nil)
+
+	dg, err := decoder.DecodeDatagram(data, agentIP)
+	if err != nil {
+		t.Fatalf("Failed to decode datagram: %v", err)
+	}
+
+	if dg.Version != 5 {
+		t.Errorf("Expected version 5, got %d", dg.Version)
+	}
+
+	if !dg.AgentAddress.Equal(agentIP) {
+		t.Errorf("Expected agent address %s, got %s", agentIP, dg.AgentAddress)
+	}
+
+	if dg.SequenceNumber != 1 {
+		t.Errorf("Expected sequence 1, got %d", dg.SequenceNumber)
+	}
+}
+
+func TestDecoder_DecodeDatagram_InvalidVersion(t *testing.T) {
+	decoder := NewDecoder(nil)
+
+	// Build a datagram with wrong version
+	buf := new(bytes.Buffer)
+	binary.Write(buf, binary.BigEndian, uint32(4)) // Wrong version
+	binary.Write(buf, binary.BigEndian, uint32(1)) // IPv4
+	buf.Write(net.ParseIP("192.168.1.1").To4())
+	binary.Write(buf, binary.BigEndian, uint32(0))
+	binary.Write(buf, binary.BigEndian, uint32(1))
+	binary.Write(buf, binary.BigEndian, uint32(0))
+	binary.Write(buf, binary.BigEndian, uint32(0))
+
+	_, err := decoder.DecodeDatagram(buf.Bytes(), nil)
+	if err == nil {
+		t.Error("Expected error for invalid version")
+	}
+}
+
+func TestDecoder_DecodeDatagram_TooShort(t *testing.T) {
+	decoder := NewDecoder(nil)
+
+	data := []byte{0, 0, 0, 5} // Just version
+	_, err := decoder.DecodeDatagram(data, nil)
+	if err == nil {
+		t.Error("Expected error for short datagram")
+	}
+}
+
+func TestDecoder_ParseEthernetHeader_IPv4TCP(t *testing.T) {
+	header := &SFlowRawPacketHeader{
+		Protocol: 1,
+		HeaderData: buildEthernetIPv4TCPHeader(
+			net.ParseIP("192.168.1.100"),
+			net.ParseIP("192.168.1.200"),
+			12345, 80,
+		),
+	}
+
+	decoder := NewDecoder(nil)
+	decoder.parseEthernetHeader(header)
+
+	if header.EtherType != 0x0800 {
+		t.Errorf("Expected EtherType 0x0800, got 0x%04x", header.EtherType)
+	}
+
+	if !header.SrcIP.Equal(net.ParseIP("192.168.1.100")) {
+		t.Errorf("Expected SrcIP 192.168.1.100, got %s", header.SrcIP)
+	}
+
+	if !header.DstIP.Equal(net.ParseIP("192.168.1.200")) {
+		t.Errorf("Expected DstIP 192.168.1.200, got %s", header.DstIP)
+	}
+
+	if header.SrcPort != 12345 {
+		t.Errorf("Expected SrcPort 12345, got %d", header.SrcPort)
+	}
+
+	if header.DstPort != 80 {
+		t.Errorf("Expected DstPort 80, got %d", header.DstPort)
+	}
+
+	if header.Protocol_L4 != 6 {
+		t.Errorf("Expected Protocol 6 (TCP), got %d", header.Protocol_L4)
+	}
+
+	if header.IPVersion != 4 {
+		t.Errorf("Expected IP version 4, got %d", header.IPVersion)
+	}
+}
+
+func TestDecoder_ToFlowMessages(t *testing.T) {
+	decoder := NewDecoder(nil)
+
+	// Build a complete datagram with a flow sample
+	agentIP := net.ParseIP("192.168.1.1")
+	header := buildEthernetIPv4TCPHeader(
+		net.ParseIP("10.0.0.1"),
+		net.ParseIP("10.0.0.2"),
+		54321, 443,
+	)
+	sample := buildFlowSample(128, 1, 2, header)
+	data := buildSFlowDatagram(agentIP, 0, 100, sample)
+
+	dg, err := decoder.DecodeDatagram(data, agentIP)
+	if err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+
+	messages := decoder.ToFlowMessages(dg)
+
+	if len(messages) == 0 {
+		t.Fatal("Expected at least one flow message")
+	}
+
+	msg := messages[0]
+
+	if msg.SamplingRate != 128 {
+		t.Errorf("Expected sampling rate 128, got %d", msg.SamplingRate)
+	}
+
+	if msg.InIf != 1 {
+		t.Errorf("Expected input interface 1, got %d", msg.InIf)
+	}
+
+	if msg.OutIf != 2 {
+		t.Errorf("Expected output interface 2, got %d", msg.OutIf)
+	}
+}
+
+func TestMacToUint64(t *testing.T) {
+	mac := net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
+	expected := uint64(0x001122334455)
+
+	result := macToUint64(mac)
+	if result != expected {
+		t.Errorf("Expected %x, got %x", expected, result)
+	}
+}
+
+func TestMacToUint64_Invalid(t *testing.T) {
+	mac := net.HardwareAddr{0x00, 0x11} // Too short
+	result := macToUint64(mac)
+	if result != 0 {
+		t.Errorf("Expected 0 for invalid MAC, got %x", result)
+	}
+}
+
+func BenchmarkDecoder_DecodeDatagram(b *testing.B) {
+	decoder := NewDecoder(nil)
+	agentIP := net.ParseIP("192.168.1.1")
+	header := buildEthernetIPv4TCPHeader(
+		net.ParseIP("10.0.0.1"),
+		net.ParseIP("10.0.0.2"),
+		54321, 443,
+	)
+	sample := buildFlowSample(128, 1, 2, header)
+	data := buildSFlowDatagram(agentIP, 0, 100, sample)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		decoder.DecodeDatagram(data, agentIP)
+	}
+}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/netsampler/goflow2/v2/transport"
@@ -13,13 +14,74 @@ func SetLogger(l *logrus.Logger) {
 	log = l
 }
 
+// ZmqConfig holds configuration for ZMQ transport
+type ZmqConfig struct {
+	Endpoints      []string       // List of ZMQ bind addresses
+	MsgType        MsgFormat      // Message format (TLV, JSON, PBUF)
+	SourceId       int            // Source ID for NetFlow
+	Compress       bool           // Enable compression (JSON only)
+	FanoutStrategy FanoutStrategy // How to distribute flows
+	Topic          string         // ZMQ topic
+	Metrics        *ZmqMetrics    // Prometheus metrics
+}
+
+// RegisterZmq registers a ZMQ transport driver with the given configuration
+// Deprecated: Use RegisterZmqWithConfig instead for multi-endpoint support
 func RegisterZmq(zmqListen string, msgType MsgFormat, sourceId int, compress bool) {
+	RegisterZmqWithConfig(&ZmqConfig{
+		Endpoints:      []string{zmqListen},
+		MsgType:        msgType,
+		SourceId:       sourceId,
+		Compress:       compress,
+		FanoutStrategy: FanoutHash,
+		Topic:          ZMQ_TOPIC,
+	})
+}
+
+// RegisterZmqWithConfig registers a ZMQ transport driver with full configuration
+func RegisterZmqWithConfig(cfg *ZmqConfig) {
+	endpoints := make([]*ZmqEndpoint, 0, len(cfg.Endpoints))
+	for _, addr := range cfg.Endpoints {
+		endpoints = append(endpoints, &ZmqEndpoint{
+			Address: addr,
+		})
+	}
+
 	z := &ZmqDriver{
-		listenAddress: zmqListen,
-		sourceId:      sourceId,
-		msgType:       msgType,
-		compress:      compress,
-		lock:          &sync.RWMutex{},
+		endpoints:      endpoints,
+		sourceId:       cfg.SourceId,
+		msgType:        cfg.MsgType,
+		compress:       cfg.Compress,
+		fanoutStrategy: cfg.FanoutStrategy,
+		topic:          cfg.Topic,
+		lock:           &sync.RWMutex{},
+		metrics:        cfg.Metrics,
 	}
 	transport.RegisterTransportDriver("zmq", z)
+}
+
+// ParseZmqEndpoints parses a comma-separated list of ZMQ endpoints
+// Format: "tcp://*:5556,tcp://*:5557" or single endpoint "tcp://*:5556"
+func ParseZmqEndpoints(endpoints string) []string {
+	parts := strings.Split(endpoints, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+// ParseFanoutStrategy parses a string into a FanoutStrategy
+func ParseFanoutStrategy(strategy string) FanoutStrategy {
+	switch strings.ToLower(strategy) {
+	case "round-robin", "roundrobin", "rr":
+		return FanoutRoundRobin
+	case "hash", "5tuple":
+		return FanoutHash
+	default:
+		return FanoutHash
+	}
 }

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -1,0 +1,108 @@
+package transport
+
+import (
+	"testing"
+)
+
+func TestParseZmqEndpoints_Single(t *testing.T) {
+	endpoints := ParseZmqEndpoints("tcp://*:5556")
+
+	if len(endpoints) != 1 {
+		t.Fatalf("Expected 1 endpoint, got %d", len(endpoints))
+	}
+
+	if endpoints[0] != "tcp://*:5556" {
+		t.Errorf("Expected tcp://*:5556, got %s", endpoints[0])
+	}
+}
+
+func TestParseZmqEndpoints_Multiple(t *testing.T) {
+	endpoints := ParseZmqEndpoints("tcp://*:5556,tcp://*:5557,tcp://*:5558")
+
+	if len(endpoints) != 3 {
+		t.Fatalf("Expected 3 endpoints, got %d", len(endpoints))
+	}
+
+	expected := []string{"tcp://*:5556", "tcp://*:5557", "tcp://*:5558"}
+	for i, e := range expected {
+		if endpoints[i] != e {
+			t.Errorf("Endpoint %d: expected %s, got %s", i, e, endpoints[i])
+		}
+	}
+}
+
+func TestParseZmqEndpoints_WithSpaces(t *testing.T) {
+	endpoints := ParseZmqEndpoints("tcp://*:5556 , tcp://*:5557 ,  tcp://*:5558")
+
+	if len(endpoints) != 3 {
+		t.Fatalf("Expected 3 endpoints, got %d", len(endpoints))
+	}
+
+	// Spaces should be trimmed
+	expected := []string{"tcp://*:5556", "tcp://*:5557", "tcp://*:5558"}
+	for i, e := range expected {
+		if endpoints[i] != e {
+			t.Errorf("Endpoint %d: expected %s, got %s", i, e, endpoints[i])
+		}
+	}
+}
+
+func TestParseZmqEndpoints_Empty(t *testing.T) {
+	endpoints := ParseZmqEndpoints("")
+
+	if len(endpoints) != 0 {
+		t.Errorf("Expected 0 endpoints for empty string, got %d", len(endpoints))
+	}
+}
+
+func TestParseZmqEndpoints_EmptyElements(t *testing.T) {
+	endpoints := ParseZmqEndpoints("tcp://*:5556,,tcp://*:5557")
+
+	if len(endpoints) != 2 {
+		t.Fatalf("Expected 2 endpoints (skip empty), got %d", len(endpoints))
+	}
+}
+
+func TestParseFanoutStrategy_Hash(t *testing.T) {
+	tests := []string{"hash", "Hash", "HASH", "5tuple"}
+	for _, s := range tests {
+		strategy := ParseFanoutStrategy(s)
+		if strategy != FanoutHash {
+			t.Errorf("Expected FanoutHash for %q, got %v", s, strategy)
+		}
+	}
+}
+
+func TestParseFanoutStrategy_RoundRobin(t *testing.T) {
+	tests := []string{"round-robin", "Round-Robin", "roundrobin", "rr", "RR"}
+	for _, s := range tests {
+		strategy := ParseFanoutStrategy(s)
+		if strategy != FanoutRoundRobin {
+			t.Errorf("Expected FanoutRoundRobin for %q, got %v", s, strategy)
+		}
+	}
+}
+
+func TestParseFanoutStrategy_Default(t *testing.T) {
+	strategy := ParseFanoutStrategy("unknown")
+	if strategy != FanoutHash {
+		t.Errorf("Expected default FanoutHash for unknown strategy, got %v", strategy)
+	}
+}
+
+func TestZmqConfig_Defaults(t *testing.T) {
+	cfg := &ZmqConfig{
+		Endpoints: []string{"tcp://*:5556"},
+		MsgType:   TLV,
+		SourceId:  0,
+	}
+
+	if len(cfg.Endpoints) != 1 {
+		t.Error("Expected 1 endpoint")
+	}
+
+	if cfg.FanoutStrategy != FanoutHash {
+		// Zero value should be FanoutHash (0)
+		t.Logf("FanoutStrategy zero value is %v", cfg.FanoutStrategy)
+	}
+}

--- a/transport/zmq.go
+++ b/transport/zmq.go
@@ -8,6 +8,9 @@ package transport
  * with [ntopng](https://www.ntop.org/products/traffic-analysis/ntop/), filling
  * the same role a [nProbe](https://www.ntop.org/products/netflow/nprobe/) or your
  * own solution.
+ *
+ * This implementation supports multi-endpoint fan-out with configurable
+ * distribution strategies (hash-based or round-robin).
  */
 
 import (
@@ -16,10 +19,14 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"hash/fnv"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	zmq "github.com/pebbe/zmq4"
 )
 
@@ -42,14 +49,83 @@ const (
 
 type MsgFormat int
 
+// FanoutStrategy determines how flows are distributed across multiple endpoints
+type FanoutStrategy int
+
+const (
+	// FanoutHash distributes flows by hashing exporter IP + 5-tuple
+	FanoutHash FanoutStrategy = iota
+	// FanoutRoundRobin distributes flows in round-robin fashion
+	FanoutRoundRobin
+)
+
+// ZmqEndpoint represents a single ZMQ endpoint
+type ZmqEndpoint struct {
+	Address   string
+	Context   *zmq.Context
+	Publisher *zmq.Socket
+	MessageID uint32
+	Active    bool
+	LastError error
+	mu        sync.RWMutex
+}
+
 type ZmqDriver struct {
-	listenAddress string
-	context       *zmq.Context
-	publisher     *zmq.Socket
-	sourceId      int
-	msgType       MsgFormat
-	compress      bool
-	lock          *sync.RWMutex
+	endpoints      []*ZmqEndpoint
+	fanoutStrategy FanoutStrategy
+	sourceId       int
+	msgType        MsgFormat
+	compress       bool
+	topic          string
+	lock           *sync.RWMutex
+	rrIndex        atomic.Uint64 // Round-robin index
+	metrics        *ZmqMetrics
+}
+
+// ZmqMetrics holds prometheus metrics for ZMQ transport
+type ZmqMetrics struct {
+	MessagesSent    *prometheus.CounterVec
+	BytesSent       *prometheus.CounterVec
+	Errors          *prometheus.CounterVec
+	EndpointsActive prometheus.Gauge
+	MessageLatency  prometheus.Histogram
+}
+
+// NewZmqMetrics creates prometheus metrics for ZMQ transport
+func NewZmqMetrics(namespace string) *ZmqMetrics {
+	return &ZmqMetrics{
+		MessagesSent: promauto.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "zmq",
+			Name:      "messages_sent_total",
+			Help:      "Total ZMQ messages sent per endpoint",
+		}, []string{"endpoint"}),
+		BytesSent: promauto.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "zmq",
+			Name:      "bytes_sent_total",
+			Help:      "Total bytes sent per endpoint",
+		}, []string{"endpoint"}),
+		Errors: promauto.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "zmq",
+			Name:      "errors_total",
+			Help:      "Total errors per endpoint",
+		}, []string{"endpoint", "error_type"}),
+		EndpointsActive: promauto.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "zmq",
+			Name:      "endpoints_active",
+			Help:      "Number of active ZMQ endpoints",
+		}),
+		MessageLatency: promauto.NewHistogram(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: "zmq",
+			Name:      "message_latency_seconds",
+			Help:      "Time to send a ZMQ message",
+			Buckets:   []float64{.0001, .0005, .001, .005, .01, .05, .1},
+		}),
+	}
 }
 
 // This is the latest header as of ntopng 6.4
@@ -75,23 +151,93 @@ func (d *ZmqDriver) Prepare() error {
 func (d *ZmqDriver) Init() error {
 	d.lock.Lock()
 	defer d.lock.Unlock()
-	d.context, _ = zmq.NewContext()
-	d.publisher, _ = d.context.NewSocket(zmq.PUB)
-	if err := d.publisher.Bind(d.listenAddress); err != nil {
-		log.Fatalf("Unable to bind: %s", err.Error())
+
+	activeCount := 0
+	for _, ep := range d.endpoints {
+		ep.mu.Lock()
+		ep.Context, _ = zmq.NewContext()
+		ep.Publisher, _ = ep.Context.NewSocket(zmq.PUB)
+
+		if err := ep.Publisher.Bind(ep.Address); err != nil {
+			log.Errorf("Unable to bind to %s: %s", ep.Address, err.Error())
+			ep.Active = false
+			ep.LastError = err
+		} else {
+			ep.Active = true
+			activeCount++
+			log.Infof("Started ZMQ publisher on: %s", ep.Address)
+		}
+		ep.mu.Unlock()
 	}
 
-	log.Infof("Started ZMQ listener on: %s", d.listenAddress)
+	if activeCount == 0 {
+		log.Fatal("No ZMQ endpoints could be bound")
+	}
 
-	//  Ensure subscriber connection has time to complete
+	if d.metrics != nil {
+		d.metrics.EndpointsActive.Set(float64(activeCount))
+	}
+
+	// Ensure subscriber connection has time to complete
 	time.Sleep(time.Second)
 	return nil
 }
 
+// selectEndpoint chooses an endpoint based on the configured strategy
+func (d *ZmqDriver) selectEndpoint(key []byte) *ZmqEndpoint {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+
+	activeEndpoints := make([]*ZmqEndpoint, 0, len(d.endpoints))
+	for _, ep := range d.endpoints {
+		ep.mu.RLock()
+		if ep.Active {
+			activeEndpoints = append(activeEndpoints, ep)
+		}
+		ep.mu.RUnlock()
+	}
+
+	if len(activeEndpoints) == 0 {
+		return nil
+	}
+
+	if len(activeEndpoints) == 1 {
+		return activeEndpoints[0]
+	}
+
+	var idx int
+	switch d.fanoutStrategy {
+	case FanoutHash:
+		// Hash on the key (which contains exporter + flow info)
+		h := fnv.New64a()
+		h.Write(key)
+		idx = int(h.Sum64() % uint64(len(activeEndpoints)))
+	case FanoutRoundRobin:
+		idx = int(d.rrIndex.Add(1) % uint64(len(activeEndpoints)))
+	default:
+		idx = 0
+	}
+
+	return activeEndpoints[idx]
+}
+
 func (d *ZmqDriver) Send(key, data []byte) error {
 	var err error
+	start := time.Now()
 	orig_len := uint32(len(data))
 	compressed_len := orig_len
+
+	// Select endpoint
+	endpoint := d.selectEndpoint(key)
+	if endpoint == nil {
+		if d.metrics != nil {
+			d.metrics.Errors.With(prometheus.Labels{
+				"endpoint":   "none",
+				"error_type": "no_active_endpoints",
+			}).Inc()
+		}
+		return fmt.Errorf("no active ZMQ endpoints available")
+	}
 
 	// Should only compress JSON
 	if d.msgType == JSON && d.compress {
@@ -108,54 +254,84 @@ func (d *ZmqDriver) Send(key, data []byte) error {
 		compressed_len = uint32(len(data))
 	}
 
-	// Lock before accessing messageId or zmq header to ensure messageId is unique
-	d.lock.Lock()
-	defer d.lock.Unlock()
+	endpoint.mu.Lock()
+	defer endpoint.mu.Unlock()
 
-	if messageId == 1 {
-		log.Info("Sending first ZMQ message.")
-	} else if messageId%1000 == 0 {
-		log.Debugf("Sending ZMQ message id %d.", messageId)
-	} else if messageId >= maxMessageId {
+	// Wrap message ID
+	if endpoint.MessageID >= maxMessageId {
 		log.Debug("Wrapping message id back to 1 to avoid overflow")
-		messageId = 1
+		endpoint.MessageID = 1
 	}
-	header := d.newZmqHeaderV3(orig_len, compressed_len)
+
+	if endpoint.MessageID == 1 {
+		log.Infof("Sending first ZMQ message to %s", endpoint.Address)
+	} else if endpoint.MessageID%1000 == 0 {
+		log.Debugf("Sending ZMQ message id %d to %s", endpoint.MessageID, endpoint.Address)
+	}
+
+	header := d.newZmqHeaderV3(endpoint, orig_len, compressed_len)
 
 	// send our header with the topic first as a multi-part message
 	hbytes, err := header.bytes()
 	if err != nil {
 		log.Errorf("Unable to serialize header: %s", err.Error())
+		if d.metrics != nil {
+			d.metrics.Errors.With(prometheus.Labels{
+				"endpoint":   endpoint.Address,
+				"error_type": "header_serialize",
+			}).Inc()
+		}
 		return err
 	}
 
-	bytes, err := d.publisher.SendBytes(hbytes, zmq.SNDMORE)
+	bytesSent, err := endpoint.Publisher.SendBytes(hbytes, zmq.SNDMORE)
 	if err != nil {
-		log.Errorf("Unable to send header: %s", err.Error())
+		log.Errorf("Unable to send header to %s: %s", endpoint.Address, err.Error())
+		if d.metrics != nil {
+			d.metrics.Errors.With(prometheus.Labels{
+				"endpoint":   endpoint.Address,
+				"error_type": "send_header",
+			}).Inc()
+		}
 		return err
 	}
-	if bytes != len(hbytes) {
-		log.Errorf("Wrote the wrong number of header bytes: %d", bytes)
+	if bytesSent != len(hbytes) {
+		log.Errorf("Wrote the wrong number of header bytes: %d", bytesSent)
 		return err
 	}
 
 	// now send the actual payload
-	if _, err = d.publisher.SendBytes(data, 0); err != nil {
+	payloadBytes, err := endpoint.Publisher.SendBytes(data, 0)
+	if err != nil {
 		log.Error(err)
+		if d.metrics != nil {
+			d.metrics.Errors.With(prometheus.Labels{
+				"endpoint":   endpoint.Address,
+				"error_type": "send_payload",
+			}).Inc()
+		}
 		return err
+	}
+
+	endpoint.MessageID++
+
+	if d.metrics != nil {
+		d.metrics.MessagesSent.With(prometheus.Labels{"endpoint": endpoint.Address}).Inc()
+		d.metrics.BytesSent.With(prometheus.Labels{"endpoint": endpoint.Address}).Add(float64(bytesSent + payloadBytes))
+		d.metrics.MessageLatency.Observe(time.Since(start).Seconds())
 	}
 
 	switch d.msgType {
 	case PBUF:
-		log.Tracef("Sent %d bytes of pbuf:\n%s", orig_len, hex.Dump(data))
+		log.Tracef("Sent %d bytes of pbuf to %s:\n%s", orig_len, endpoint.Address, hex.Dump(data))
 	case JSON:
 		if d.compress {
-			log.Tracef("Sent %d bytes of zlib json:\n%s", compressed_len, hex.Dump(data))
+			log.Tracef("Sent %d bytes of zlib json to %s:\n%s", compressed_len, endpoint.Address, hex.Dump(data))
 		} else {
-			log.Tracef("Sent %d bytes of json: %s", orig_len, string(data))
+			log.Tracef("Sent %d bytes of json to %s: %s", orig_len, endpoint.Address, string(data))
 		}
 	case TLV:
-		log.Tracef("Sent %d bytes of ntop tlv:\n%s", orig_len, hex.Dump(data))
+		log.Tracef("Sent %d bytes of ntop tlv to %s:\n%s", orig_len, endpoint.Address, hex.Dump(data))
 	default:
 		log.Errorf("Sent %d bytes of unknown message type %d", orig_len, d.msgType)
 	}
@@ -164,11 +340,24 @@ func (d *ZmqDriver) Send(key, data []byte) error {
 }
 
 func (d *ZmqDriver) Close() error {
-	// Do stuff here
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	for _, ep := range d.endpoints {
+		ep.mu.Lock()
+		if ep.Publisher != nil {
+			ep.Publisher.Close()
+		}
+		if ep.Context != nil {
+			ep.Context.Term()
+		}
+		ep.Active = false
+		ep.mu.Unlock()
+	}
 	return nil
 }
 
-func (d *ZmqDriver) newZmqHeaderV3(orig_length uint32, compressed_len uint32) *zmqHeaderV3 {
+func (d *ZmqDriver) newZmqHeaderV3(ep *ZmqEndpoint, orig_length uint32, compressed_len uint32) *zmqHeaderV3 {
 	var flags uint8 = 0
 	if d.msgType == TLV {
 		flags |= ZMQ_MSG_V4_FLAG_TLV
@@ -177,16 +366,20 @@ func (d *ZmqDriver) newZmqHeaderV3(orig_length uint32, compressed_len uint32) *z
 		flags |= ZMQ_MSG_V4_FLAG_COMPRESSED
 	}
 
+	topic := d.topic
+	if topic == "" {
+		topic = ZMQ_TOPIC
+	}
+
 	z := &zmqHeaderV3{
-		url:               ZMQ_TOPIC,
+		url:               topic,
 		version:           ZMQ_MSG_VERSION_4,
 		flags:             flags,
 		uncompressed_size: orig_length,
 		compressed_size:   compressed_len,
-		msg_id:            messageId,
+		msg_id:            ep.MessageID,
 		source_id:         uint32(d.sourceId),
 	}
-	messageId++
 
 	return z
 }
@@ -251,4 +444,48 @@ func (zh *zmqHeaderV3) bytes() ([]byte, error) {
 		return nil, err
 	}
 	return bBuf.Bytes(), nil
+}
+
+// GetActiveEndpoints returns a list of active endpoint addresses
+func (d *ZmqDriver) GetActiveEndpoints() []string {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+
+	result := make([]string, 0, len(d.endpoints))
+	for _, ep := range d.endpoints {
+		ep.mu.RLock()
+		if ep.Active {
+			result = append(result, ep.Address)
+		}
+		ep.mu.RUnlock()
+	}
+	return result
+}
+
+// SetEndpointActive sets the active state of an endpoint (for reconnection logic)
+func (d *ZmqDriver) SetEndpointActive(address string, active bool) {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+
+	for _, ep := range d.endpoints {
+		if ep.Address == address {
+			ep.mu.Lock()
+			ep.Active = active
+			ep.mu.Unlock()
+
+			// Update metrics
+			if d.metrics != nil {
+				activeCount := 0
+				for _, e := range d.endpoints {
+					e.mu.RLock()
+					if e.Active {
+						activeCount++
+					}
+					e.mu.RUnlock()
+				}
+				d.metrics.EndpointsActive.Set(float64(activeCount))
+			}
+			return
+		}
+	}
 }


### PR DESCRIPTION
## Summary

This PR significantly expands netflow2ng's capabilities by adding sFlow v5 support, per-exporter sampling rate tracking with automatic upscaling, flow deduplication, and multi-endpoint ZMQ fan-out with configurable distribution strategies. The implementation includes a high-performance worker pool architecture with bounded queues and object pooling to minimize GC pressure.

## Key Changes

### Protocol & Collection
- **sFlow v5 support**: New sFlow collector with dedicated worker pool and metrics
- **Sampling rate tracking**: Automatic detection from IPFIX options templates and sFlow headers
- **Configurable upscaling**: Optional automatic scaling of bytes/packets based on sampling rates
- **Per-exporter statistics**: Registry tracking packets, bytes, flows, and errors per exporter

### Performance & Architecture
- **Fixed worker pool**: Replaced unbounded goroutine-per-packet with bounded queue and fixed worker count
- **Ring buffer**: Lock-free circular buffer for efficient packet queuing
- **Object pooling**: `sync.Pool` for byte buffers and work items to reduce GC pressure
- **Metrics**: Comprehensive Prometheus metrics for queue depth, processing latency, and per-worker stats

### Flow Processing
- **Flow deduplication**: Optional per-exporter dedup cache with configurable TTL and size bounds
- **Heuristic filtering**: Avoids false positives on legitimate flow updates (increased bytes/packets, advancing sequences)
- **Dedup metrics**: Cache hits/misses, duplicates suppressed, evictions tracked

### ZMQ & Distribution
- **Multi-endpoint fan-out**: Support for multiple ZMQ endpoints (comma-separated)
- **Hash-based distribution**: Routes flows to endpoints based on exporter IP + 5-tuple hash for flow affinity
- **Round-robin distribution**: Alternative load-balancing strategy across endpoints
- **Endpoint metrics**: Per-endpoint message/byte counts and error tracking

### Configuration & Observability
- **Expanded CLI flags**: New options for sFlow, sampling, dedup, queue size, and fanout strategy
- **HTTP endpoints**: `/sampling` for per-exporter sampling info, `/dedup` for cache statistics
- **Enhanced logging**: Timestamps enabled, structured logging for configuration changes
- **Version output**: Expanded to show protocol support and feature list

### Documentation
- **Comprehensive README**: Expanded from ~80 to ~365 lines with:
  - Feature overview and use cases
  - Installation and Docker setup
  - Detailed configuration examples (basic, sFlow, multi-endpoint, high-throughput)
  - Architecture diagram
  - Prometheus metrics reference
  - Deduplication heuristics explanation
  - Comparison with nProbe

## Implementation Details

- **Collector package**: New `pool.go` (worker pool, ring buffer), `buffer.go` (object pools), `exporter.go` (registry & metrics)
- **Sampling package**: Tracks sampling rates per exporter with optional upscaling
- **Dedup package**: LRU-style cache with TTL-based eviction and heuristic filtering
- **sFlow package**: Native sFlow v5 decoder with flow message conversion
- **Transport**: Enhanced ZMQ transport with multi-endpoint support and fanout strategies
- **Tests**: Comprehensive unit tests for ring buffer, worker pool, and concurrent scenarios

## Backward Compatibility

All changes are backward compatible. Existing single-endpoint configurations work unchanged. New features (sFlow, dedup, multi-endpoint) are opt-in via CLI flags.

https://claude.ai/code/session_01AR6sfWp6iGEfcpFXTv5vG8